### PR TITLE
MMSBUILD-263 (Mark) Use standard Go integer types

### DIFF
--- a/diskperf.go
+++ b/diskperf.go
@@ -29,12 +29,12 @@ type DiskPerformanceInfo struct {
 	ReadTime            int64
 	WriteTime           int64
 	IdleTime            int64
-	ReadCount           uint32
-	WriteCount          uint32
-	QueueDepth          uint32
-	SplitCount          uint32
+	ReadCount           uint
+	WriteCount          uint
+	QueueDepth          uint
+	SplitCount          uint
 	QueryTime           int64
-	StorageDeviceNumber uint32
+	StorageDeviceNumber uint
 	StorageManagerName  string
 }
 
@@ -71,12 +71,12 @@ func GetDiskPerformanceInfo(rootPathName string) (*DiskPerformanceInfo, error) {
 		ReadTime:            diskPerformance.ReadTime,
 		WriteTime:           diskPerformance.WriteTime,
 		IdleTime:            diskPerformance.IdleTime,
-		ReadCount:           diskPerformance.ReadCount,
-		WriteCount:          diskPerformance.WriteCount,
-		QueueDepth:          diskPerformance.QueueDepth,
-		SplitCount:          diskPerformance.SplitCount,
+		ReadCount:           uint(diskPerformance.ReadCount),
+		WriteCount:          uint(diskPerformance.WriteCount),
+		QueueDepth:          uint(diskPerformance.QueueDepth),
+		SplitCount:          uint(diskPerformance.SplitCount),
 		QueryTime:           diskPerformance.QueryTime,
-		StorageDeviceNumber: diskPerformance.StorageDeviceNumber,
+		StorageDeviceNumber: uint(diskPerformance.StorageDeviceNumber),
 		StorageManagerName:  syscall.UTF16ToString(diskPerformance.StorageManagerName[:]),
 	}, nil
 }

--- a/eventlog.go
+++ b/eventlog.go
@@ -35,7 +35,7 @@ const (
 
 type EventSourceRegistration struct {
 	SourceName           string
-	CategoryCount        uint32
+	CategoryCount        uint
 	CategoryMessageFile  string
 	EventMessageFile     string
 	ParameterMessageFile string
@@ -51,7 +51,7 @@ func (self *EventSourceRegistration) Install() error {
 	}
 	defer key.Close()
 	if self.CategoryMessageFile != "" {
-		if err := key.SetValueDWORD("CategoryCount", self.CategoryCount); err != nil {
+		if err := key.SetValueDWORD("CategoryCount", uint32(self.CategoryCount)); err != nil {
 			return err
 		}
 		if err := key.SetValueString("CategoryMessageFile", self.CategoryMessageFile); err != nil {
@@ -73,8 +73,8 @@ func (self *EventSourceRegistration) Install() error {
 
 type EventLogEvent struct {
 	Type     EventType
-	Category uint16
-	EventID  uint32
+	Category uint
+	EventID  uint
 	Strings  []string
 	Data     []byte
 }
@@ -121,8 +121,8 @@ func (self *EventSource) Report(event *EventLogEvent) error {
 	err := wrappers.ReportEvent(
 		self.handle,
 		uint16(event.Type),
-		event.Category,
-		event.EventID,
+		uint16(event.Category),
+		uint32(event.EventID),
 		nil,
 		stringCount,
 		dataSize,
@@ -134,7 +134,7 @@ func (self *EventSource) Report(event *EventLogEvent) error {
 	return nil
 }
 
-func (self *EventSource) Error(eventID uint32, strings ...string) error {
+func (self *EventSource) Error(eventID uint, strings ...string) error {
 	return self.Report(&EventLogEvent{
 		Type:    EventTypeError,
 		EventID: eventID,
@@ -142,7 +142,7 @@ func (self *EventSource) Error(eventID uint32, strings ...string) error {
 	})
 }
 
-func (self *EventSource) Warning(eventID uint32, strings ...string) error {
+func (self *EventSource) Warning(eventID uint, strings ...string) error {
 	return self.Report(&EventLogEvent{
 		Type:    EventTypeWarning,
 		EventID: eventID,
@@ -150,7 +150,7 @@ func (self *EventSource) Warning(eventID uint32, strings ...string) error {
 	})
 }
 
-func (self *EventSource) Info(eventID uint32, strings ...string) error {
+func (self *EventSource) Info(eventID uint, strings ...string) error {
 	return self.Report(&EventLogEvent{
 		Type:    EventTypeInformation,
 		EventID: eventID,

--- a/fileversion.go
+++ b/fileversion.go
@@ -89,10 +89,10 @@ const (
 )
 
 type FileVersionNumber struct {
-	Major    uint16
-	Minor    uint16
-	Build    uint16
-	Revision uint16
+	Major    uint
+	Minor    uint
+	Build    uint
+	Revision uint
 }
 
 func (self *FileVersionNumber) String() string {
@@ -112,28 +112,28 @@ func StringToFileVersionNumber(s string) (FileVersionNumber, error) {
 		if err != nil {
 			return FileVersionNumber{}, err
 		}
-		version.Major = uint16(n)
+		version.Major = uint(n)
 	}
 	if len(parts) >= 2 {
 		n, err := strconv.ParseUint(parts[1], 10, 16)
 		if err != nil {
 			return FileVersionNumber{}, err
 		}
-		version.Minor = uint16(n)
+		version.Minor = uint(n)
 	}
 	if len(parts) >= 3 {
 		n, err := strconv.ParseUint(parts[2], 10, 16)
 		if err != nil {
 			return FileVersionNumber{}, err
 		}
-		version.Build = uint16(n)
+		version.Build = uint(n)
 	}
 	if len(parts) >= 4 {
 		n, err := strconv.ParseUint(parts[3], 10, 16)
 		if err != nil {
 			return FileVersionNumber{}, err
 		}
-		version.Revision = uint16(n)
+		version.Revision = uint(n)
 	}
 	return version, nil
 }
@@ -199,17 +199,17 @@ func (self *FileVersion) GetFixedFileInfo() (*FixedFileInfo, error) {
 	}
 	return &FixedFileInfo{
 		FileVersion: FileVersionNumber{
-			Major:    wrappers.HIWORD(ffi.FileVersionMS),
-			Minor:    wrappers.LOWORD(ffi.FileVersionMS),
-			Build:    wrappers.HIWORD(ffi.FileVersionLS),
-			Revision: wrappers.LOWORD(ffi.FileVersionLS),
+			Major:    uint(wrappers.HIWORD(ffi.FileVersionMS)),
+			Minor:    uint(wrappers.LOWORD(ffi.FileVersionMS)),
+			Build:    uint(wrappers.HIWORD(ffi.FileVersionLS)),
+			Revision: uint(wrappers.LOWORD(ffi.FileVersionLS)),
 		},
 
 		ProductVersion: FileVersionNumber{
-			Major:    wrappers.HIWORD(ffi.ProductVersionMS),
-			Minor:    wrappers.LOWORD(ffi.ProductVersionMS),
-			Build:    wrappers.HIWORD(ffi.ProductVersionLS),
-			Revision: wrappers.LOWORD(ffi.ProductVersionLS),
+			Major:    uint(wrappers.HIWORD(ffi.ProductVersionMS)),
+			Minor:    uint(wrappers.LOWORD(ffi.ProductVersionMS)),
+			Build:    uint(wrappers.HIWORD(ffi.ProductVersionLS)),
+			Revision: uint(wrappers.LOWORD(ffi.ProductVersionLS)),
 		},
 
 		FileFlags:   VerFileFlags(ffi.FileFlags),

--- a/firewall.go
+++ b/firewall.go
@@ -449,7 +449,7 @@ func (self *FirewallRuleCollection) Close() error {
 	return nil
 }
 
-func (self *FirewallRuleCollection) GetCount() (int32, error) {
+func (self *FirewallRuleCollection) GetCount() (int, error) {
 	if self.object == nil {
 		return 0, NewWindowsError("INetFwRules::get_Count", COMErrorPointer)
 	}
@@ -457,7 +457,7 @@ func (self *FirewallRuleCollection) GetCount() (int32, error) {
 	if hr := self.object.Get_Count(&count); wrappers.FAILED(hr) {
 		return 0, NewWindowsError("INetFwRules::get_Count", COMError(hr))
 	}
-	return count, nil
+	return int(count), nil
 }
 
 func (self *FirewallRuleCollection) Add(rule *FirewallRule) error {
@@ -558,7 +558,7 @@ func (self *FirewallManager) Close() error {
 	return nil
 }
 
-func (self *FirewallManager) IsPortAllowed(imageFileName string, ipVersion FirewallIPVersion, portNumber int32, localAddress string, ipProtocol FirewallProtocol) (allowed bool, restricted bool, err error) {
+func (self *FirewallManager) IsPortAllowed(imageFileName string, ipVersion FirewallIPVersion, portNumber int, localAddress string, ipProtocol FirewallProtocol) (allowed bool, restricted bool, err error) {
 	if self.object == nil {
 		err = COMErrorPointer
 		return
@@ -582,7 +582,7 @@ func (self *FirewallManager) IsPortAllowed(imageFileName string, ipVersion Firew
 	hr := self.object.IsPortAllowed(
 		imageFileNameRaw,
 		int32(ipVersion),
-		portNumber,
+		int32(portNumber),
 		localAddressRaw,
 		int32(ipProtocol),
 		&allowedRaw,

--- a/resource.go
+++ b/resource.go
@@ -54,8 +54,8 @@ var (
 
 type ResourceId *uint16
 
-func IntResourceId(resourceId uint16) ResourceId {
-	return ResourceId(wrappers.MAKEINTRESOURCE(resourceId))
+func IntResourceId(resourceId uint) ResourceId {
+	return ResourceId(wrappers.MAKEINTRESOURCE(uint16(resourceId)))
 }
 
 func StringResourceId(resourceId string) ResourceId {

--- a/security.go
+++ b/security.go
@@ -27,15 +27,15 @@ type SecurityID struct {
 	sid *wrappers.SID
 }
 
-func (self SecurityID) GetLength() uint32 {
-	return wrappers.GetLengthSid(self.sid)
+func (self SecurityID) GetLength() uint {
+	return uint(wrappers.GetLengthSid(self.sid))
 }
 
 func (self SecurityID) Copy() (SecurityID, error) {
 	length := self.GetLength()
 	buf := make([]byte, length)
 	sid := (*wrappers.SID)(unsafe.Pointer(&buf[0]))
-	err := wrappers.CopySid(length, sid, self.sid)
+	err := wrappers.CopySid(uint32(length), sid, self.sid)
 	if err != nil {
 		return SecurityID{}, NewWindowsError("CopySid", err)
 	}
@@ -54,7 +54,7 @@ func GetFileOwner(path string) (SecurityID, error) {
 		nil,
 		0,
 		&needed)
-	buf := make([]uint8, needed)
+	buf := make([]byte, needed)
 	err := wrappers.GetFileSecurity(
 		syscall.StringToUTF16Ptr(path),
 		wrappers.OWNER_SECURITY_INFORMATION,

--- a/service.go
+++ b/service.go
@@ -238,7 +238,7 @@ func (self *Service) GetDescription() (string, error) {
 	return LpstrToString(desc.Description), nil
 }
 
-func (self *Service) GetProcessID() (uint32, error) {
+func (self *Service) GetProcessID() (uint, error) {
 	var status wrappers.SERVICE_STATUS_PROCESS
 	size := uint32(unsafe.Sizeof(status))
 	err := wrappers.QueryServiceStatusEx(
@@ -250,7 +250,7 @@ func (self *Service) GetProcessID() (uint32, error) {
 	if err != nil {
 		return 0, NewWindowsError("QueryServiceStatusEx", err)
 	}
-	return status.ProcessId, nil
+	return uint(status.ProcessId), nil
 }
 
 func (self *Service) GetStatus() (*ServiceStatusInfo, error) {

--- a/sysinfo.go
+++ b/sysinfo.go
@@ -34,9 +34,9 @@ const (
 
 type ProcessorInfo struct {
 	ProcessorArchitecture ProcessorArchitecture
-	NumberOfProcessors    uint32
-	ProcessorLevel        uint16
-	ProcessorRevision     uint16
+	NumberOfProcessors    uint
+	ProcessorLevel        uint
+	ProcessorRevision     uint
 }
 
 func GetProcessorInfo() *ProcessorInfo {
@@ -44,8 +44,8 @@ func GetProcessorInfo() *ProcessorInfo {
 	wrappers.GetSystemInfo(&si)
 	return &ProcessorInfo{
 		ProcessorArchitecture: ProcessorArchitecture(si.ProcessorArchitecture),
-		NumberOfProcessors:    si.NumberOfProcessors,
-		ProcessorLevel:        si.ProcessorLevel,
-		ProcessorRevision:     si.ProcessorRevision,
+		NumberOfProcessors:    uint(si.NumberOfProcessors),
+		ProcessorLevel:        uint(si.ProcessorLevel),
+		ProcessorRevision:     uint(si.ProcessorRevision),
 	}
 }

--- a/version.go
+++ b/version.go
@@ -82,20 +82,20 @@ type VersionCheck struct {
 	conditionMask uint64
 }
 
-func (self *VersionCheck) MajorVersion(op VerRelOp, value uint32) {
-	self.osvi.MajorVersion = value
+func (self *VersionCheck) MajorVersion(op VerRelOp, value uint) {
+	self.osvi.MajorVersion = uint32(value)
 	self.typeMask |= wrappers.VER_MAJORVERSION
 	self.conditionMask = wrappers.VerSetConditionMask(self.conditionMask, wrappers.VER_MAJORVERSION, uint8(op))
 }
 
-func (self *VersionCheck) MinorVersion(op VerRelOp, value uint32) {
-	self.osvi.MinorVersion = value
+func (self *VersionCheck) MinorVersion(op VerRelOp, value uint) {
+	self.osvi.MinorVersion = uint32(value)
 	self.typeMask |= wrappers.VER_MINORVERSION
 	self.conditionMask = wrappers.VerSetConditionMask(self.conditionMask, wrappers.VER_MINORVERSION, uint8(op))
 }
 
-func (self *VersionCheck) BuildNumber(op VerRelOp, value uint32) {
-	self.osvi.BuildNumber = value
+func (self *VersionCheck) BuildNumber(op VerRelOp, value uint) {
+	self.osvi.BuildNumber = uint32(value)
 	self.typeMask |= wrappers.VER_BUILDNUMBER
 	self.conditionMask = wrappers.VerSetConditionMask(self.conditionMask, wrappers.VER_BUILDNUMBER, uint8(op))
 }
@@ -106,14 +106,14 @@ func (self *VersionCheck) Platform(op VerRelOp, value VerPlatform) {
 	self.conditionMask = wrappers.VerSetConditionMask(self.conditionMask, wrappers.VER_PLATFORMID, uint8(op))
 }
 
-func (self *VersionCheck) ServicePackMajor(op VerRelOp, value uint16) {
-	self.osvi.ServicePackMajor = value
+func (self *VersionCheck) ServicePackMajor(op VerRelOp, value uint) {
+	self.osvi.ServicePackMajor = uint16(value)
 	self.typeMask |= wrappers.VER_SERVICEPACKMAJOR
 	self.conditionMask = wrappers.VerSetConditionMask(self.conditionMask, wrappers.VER_SERVICEPACKMAJOR, uint8(op))
 }
 
-func (self *VersionCheck) ServicePackMinor(op VerRelOp, value uint16) {
-	self.osvi.ServicePackMinor = value
+func (self *VersionCheck) ServicePackMinor(op VerRelOp, value uint) {
+	self.osvi.ServicePackMinor = uint16(value)
 	self.typeMask |= wrappers.VER_SERVICEPACKMINOR
 	self.conditionMask = wrappers.VerSetConditionMask(self.conditionMask, wrappers.VER_SERVICEPACKMINOR, uint8(op))
 }

--- a/volume.go
+++ b/volume.go
@@ -49,8 +49,8 @@ const (
 
 type VolumeInfo struct {
 	VolumeName             string
-	VolumeSerialNumber     uint32
-	MaximumComponentLength uint32
+	VolumeSerialNumber     uint
+	MaximumComponentLength uint
 	FileSystemFlags        FileSystemFlags
 	FileSystemName         string
 }
@@ -87,8 +87,8 @@ func GetVolumeInfo(rootPathName string) (*VolumeInfo, error) {
 	}
 	return &VolumeInfo{
 		VolumeName:             syscall.UTF16ToString(volumeNameBuffer),
-		VolumeSerialNumber:     volumeSerialNumber,
-		MaximumComponentLength: maximumComponentLength,
+		VolumeSerialNumber:     uint(volumeSerialNumber),
+		MaximumComponentLength: uint(maximumComponentLength),
 		FileSystemFlags:        FileSystemFlags(fileSystemFlags),
 		FileSystemName:         syscall.UTF16ToString(fileSystemNameBuffer),
 	}, nil

--- a/wrappers/tlhelp32.go
+++ b/wrappers/tlhelp32.go
@@ -52,7 +52,7 @@ type MODULEENTRY32 struct {
 	ProcessID    uint32
 	GlblcntUsage uint32
 	ProccntUsage uint32
-	ModBaseAddr  *uint8
+	ModBaseAddr  *byte
 	ModBaseSize  uint32
 	Module       syscall.Handle
 	ModuleName   [MAX_MODULE_NAME32 + 1]uint16

--- a/wrappers/winbase.go
+++ b/wrappers/winbase.go
@@ -756,7 +756,7 @@ func FreeSid(sid *SID) {
 	procFreeSid.Call(uintptr(unsafe.Pointer(sid)))
 }
 
-func GetFileSecurity(fileName *uint16, requestedInformation uint32, securityDescriptor *uint8, length uint32, lengthNeeded *uint32) error {
+func GetFileSecurity(fileName *uint16, requestedInformation uint32, securityDescriptor *byte, length uint32, lengthNeeded *uint32) error {
 	r1, _, e1 := procGetFileSecurityW.Call(
 		uintptr(unsafe.Pointer(fileName)),
 		uintptr(requestedInformation),
@@ -778,7 +778,7 @@ func GetLengthSid(sid *SID) uint32 {
 	return uint32(r1)
 }
 
-func GetSecurityDescriptorOwner(securityDescriptor *uint8, owner **SID, ownerDefaulted *bool) error {
+func GetSecurityDescriptorOwner(securityDescriptor *byte, owner **SID, ownerDefaulted *bool) error {
 	var ownerDefaultedRaw int32
 	r1, _, e1 := procGetSecurityDescriptorOwner.Call(
 		uintptr(unsafe.Pointer(securityDescriptor)),


### PR DESCRIPTION
@markbenvenuto Please note that the registry functions were deliberately left using `uint32` since they semantically work with 32-bit values.