### PR TITLE
Prevent invalid heap pointer panic from resource ids

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -18,48 +18,48 @@ package gowin32
 
 import (
 	"github.com/winlabs/gowin32/wrappers"
-
 	"syscall"
+	"unsafe"
 )
 
-type ResourceType *uint16
+type ResourceType uintptr
 
 func CustomResourceType(resourceTypeName string) ResourceType {
-	return ResourceType(syscall.StringToUTF16Ptr(resourceTypeName))
+	return ResourceType(unsafe.Pointer(syscall.StringToUTF16Ptr(resourceTypeName)))
 }
 
 var (
-	ResourceTypeCursor        ResourceType = wrappers.RT_CURSOR
-	ResourceTypeBitmap        ResourceType = wrappers.RT_BITMAP
-	ResourceTypeIcon          ResourceType = wrappers.RT_ICON
-	ResourceTypeMenu          ResourceType = wrappers.RT_MENU
-	ResourceTypeDialog        ResourceType = wrappers.RT_DIALOG
-	ResourceTypeString        ResourceType = wrappers.RT_STRING
-	ResourceTypeFontDir       ResourceType = wrappers.RT_FONTDIR
-	ResourceTypeFont          ResourceType = wrappers.RT_FONT
-	ResourceTypeAccelerator   ResourceType = wrappers.RT_ACCELERATOR
-	ResourceTypeRCData        ResourceType = wrappers.RT_RCDATA
-	ResourceTypeMessageTable  ResourceType = wrappers.RT_MESSAGETABLE
-	ResourceTypeGroupCursor   ResourceType = wrappers.RT_GROUP_CURSOR
-	ResourceTypeGroupIcon     ResourceType = wrappers.RT_GROUP_ICON
-	ResourceTypeVersion       ResourceType = wrappers.RT_VERSION
-	ResourceTypeDialogInclude ResourceType = wrappers.RT_DLGINCLUDE
-	ResourceTypePlugPlay      ResourceType = wrappers.RT_PLUGPLAY
-	ResourceTypeVxD           ResourceType = wrappers.RT_VXD
-	ResourceTypeAniCursor     ResourceType = wrappers.RT_ANICURSOR
-	ResourceTypeAniIcon       ResourceType = wrappers.RT_ANIICON
-	ResourceTypeHTML          ResourceType = wrappers.RT_HTML
-	ResourceTypeManifest      ResourceType = wrappers.RT_MANIFEST
+	ResourceTypeCursor        ResourceType = ResourceType(wrappers.RT_CURSOR)
+	ResourceTypeBitmap        ResourceType = ResourceType(wrappers.RT_BITMAP)
+	ResourceTypeIcon          ResourceType = ResourceType(wrappers.RT_ICON)
+	ResourceTypeMenu          ResourceType = ResourceType(wrappers.RT_MENU)
+	ResourceTypeDialog        ResourceType = ResourceType(wrappers.RT_DIALOG)
+	ResourceTypeString        ResourceType = ResourceType(wrappers.RT_STRING)
+	ResourceTypeFontDir       ResourceType = ResourceType(wrappers.RT_FONTDIR)
+	ResourceTypeFont          ResourceType = ResourceType(wrappers.RT_FONT)
+	ResourceTypeAccelerator   ResourceType = ResourceType(wrappers.RT_ACCELERATOR)
+	ResourceTypeRCData        ResourceType = ResourceType(wrappers.RT_RCDATA)
+	ResourceTypeMessageTable  ResourceType = ResourceType(wrappers.RT_MESSAGETABLE)
+	ResourceTypeGroupCursor   ResourceType = ResourceType(wrappers.RT_GROUP_CURSOR)
+	ResourceTypeGroupIcon     ResourceType = ResourceType(wrappers.RT_GROUP_ICON)
+	ResourceTypeVersion       ResourceType = ResourceType(wrappers.RT_VERSION)
+	ResourceTypeDialogInclude ResourceType = ResourceType(wrappers.RT_DLGINCLUDE)
+	ResourceTypePlugPlay      ResourceType = ResourceType(wrappers.RT_PLUGPLAY)
+	ResourceTypeVxD           ResourceType = ResourceType(wrappers.RT_VXD)
+	ResourceTypeAniCursor     ResourceType = ResourceType(wrappers.RT_ANICURSOR)
+	ResourceTypeAniIcon       ResourceType = ResourceType(wrappers.RT_ANIICON)
+	ResourceTypeHTML          ResourceType = ResourceType(wrappers.RT_HTML)
+	ResourceTypeManifest      ResourceType = ResourceType(wrappers.RT_MANIFEST)
 )
 
-type ResourceId *uint16
+type ResourceId uintptr
 
 func IntResourceId(resourceId uint) ResourceId {
 	return ResourceId(wrappers.MAKEINTRESOURCE(uint16(resourceId)))
 }
 
 func StringResourceId(resourceId string) ResourceId {
-	return ResourceId(syscall.StringToUTF16Ptr(resourceId))
+	return ResourceId(unsafe.Pointer(syscall.StringToUTF16Ptr(resourceId)))
 }
 
 type ResourceUpdate struct {
@@ -95,8 +95,8 @@ func (self *ResourceUpdate) Save() error {
 func (self *ResourceUpdate) Update(resourceType ResourceType, resourceId ResourceId, language Language, data []byte) error {
 	err := wrappers.UpdateResource(
 		self.handle,
-		(*uint16)(resourceType),
-		(*uint16)(resourceId),
+		uintptr(resourceType),
+		uintptr(resourceId),
 		uint16(language),
 		&data[0],
 		uint32(len(data)))
@@ -109,8 +109,8 @@ func (self *ResourceUpdate) Update(resourceType ResourceType, resourceId Resourc
 func (self *ResourceUpdate) Delete(resourceType ResourceType, resourceId ResourceId, language Language) error {
 	err := wrappers.UpdateResource(
 		self.handle,
-		(*uint16)(resourceType),
-		(*uint16)(resourceId),
+		uintptr(resourceType),
+		uintptr(resourceId),
 		uint16(language),
 		nil,
 		0)

--- a/wrappers/winbase.go
+++ b/wrappers/winbase.go
@@ -406,7 +406,7 @@ func CreateFile(fileName *uint16, desiredAccess uint32, shareMode uint32, securi
 	return handle, nil
 }
 
-func CreateJobObject(jobAttributes* SECURITY_ATTRIBUTES, name *uint16) (syscall.Handle, error) {
+func CreateJobObject(jobAttributes *SECURITY_ATTRIBUTES, name *uint16) (syscall.Handle, error) {
 	r1, _, e1 := procCreateJobObjectW.Call(
 		uintptr(unsafe.Pointer(jobAttributes)),
 		uintptr(unsafe.Pointer(name)))
@@ -967,7 +967,7 @@ func OpenJobObject(desiredAccess uint32, inheritHandle bool, name *uint16) (sysc
 	} else {
 		inheritHandleRaw = 0
 	}
-	r1, _, e1 :=  procOpenJobObjectW.Call(
+	r1, _, e1 := procOpenJobObjectW.Call(
 		uintptr(desiredAccess),
 		uintptr(inheritHandleRaw),
 		uintptr(unsafe.Pointer(name)))
@@ -1148,11 +1148,11 @@ func TerminateProcess(process syscall.Handle, exitCode uint32) error {
 	return nil
 }
 
-func UpdateResource(update syscall.Handle, resourceType *uint16, name *uint16, language uint16, data *byte, cbData uint32) error {
+func UpdateResource(update syscall.Handle, resourceType uintptr, name uintptr, language uint16, data *byte, cbData uint32) error {
 	r1, _, e1 := procUpdateResourceW.Call(
 		uintptr(update),
-		uintptr(unsafe.Pointer(resourceType)),
-		uintptr(unsafe.Pointer(name)),
+		resourceType,
+		name,
 		uintptr(language),
 		uintptr(unsafe.Pointer(data)),
 		uintptr(cbData))

--- a/wrappers/winuser.go
+++ b/wrappers/winuser.go
@@ -16,12 +16,8 @@
 
 package wrappers
 
-import (
-	"unsafe"
-)
-
-func MAKEINTRESOURCE(integer uint16) *uint16 {
-	return (*uint16)(unsafe.Pointer(uintptr(integer)))
+func MAKEINTRESOURCE(integer uint16) uintptr {
+	return uintptr(integer)
 }
 
 var (


### PR DESCRIPTION
@dgolub - This one is a little tricky.

See this code first for a repro of the bug I found
```
package main

import (
	"runtime"
	"unsafe"
)

func MAKEINTRESOURCE(integer uint16) *uint8 {
	return (*uint8)(unsafe.Pointer(uintptr(integer)))
}

var (
	test1 = MAKEINTRESOURCE(1)
)

func main() {
	runtime.GC()
}
```

I'm not sure if code that uses this package has crashed because of this but when testing earlier I hit it every time. It seems to depend on when GC runs and inspects the pointer as if it were a heap pointer which clearly points to something outside of the runtime's heap. Because of this, it is dangerous to allow MAKEINTRESOURCE to return pointers that are just hiding integral values. Instead, I've changed it to use uintptrs which serve this purpose perfectly. We want to store a pointer address as an integral type, not a pointer.

These changes preserve compatibility as long as ResourceType and ResourceId were being used to call funcs/methods in this package.

Besides this kind of issue happening on the heap, it can happen with a stack allocated pointer as well, the stack pointer analysis will catch an invalid pointer and panic similarly. This is why I changed the Update/Delete/UpdateResource functions to only take uintptrs for these types of resources. Any other choice is not safe if there's a possibility of having resource ids/types that have numeric values that correspond to invalid pointers in the stack or heap.

I know this breaks the wrapping convention but it will now be golang safe.

Note: Go 1.3 shouldn't complain about this but go 1.4 will. I've also found that syscall.Handle uses this same idea in order to avoid being treated as a go managed pointer.