### PR TITLE
MMSP-12035 (Mark/Eric) Add support for critical sections

### DIFF
--- a/critsect.go
+++ b/critsect.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2014 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the license is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gowin32
+
+import (
+	"github.com/winlabs/gowin32/wrappers"
+)
+
+type CriticalSection struct {
+	nativeCriticalSection wrappers.CRITICAL_SECTION
+}
+
+func NewCriticalSection() *CriticalSection {
+	cs := CriticalSection{}
+	wrappers.InitializeCriticalSection(&cs.nativeCriticalSection)
+	return &cs
+}
+
+func (self *CriticalSection) Close() error {
+	wrappers.DeleteCriticalSection(&self.nativeCriticalSection)
+	return nil
+}
+
+func (self *CriticalSection) Lock() {
+	wrappers.EnterCriticalSection(&self.nativeCriticalSection)
+}
+
+func (self *CriticalSection) Unlock() {
+	wrappers.LeaveCriticalSection(&self.nativeCriticalSection)
+}
+
+func (self *CriticalSection) TryLock() bool {
+	return wrappers.TryEnterCriticalSection(&self.nativeCriticalSection)
+}

--- a/wrappers/winnt.go
+++ b/wrappers/winnt.go
@@ -30,6 +30,11 @@ type LUID struct {
 	HighPart int32
 }
 
+type LIST_ENTRY struct {
+	Flink *LIST_ENTRY
+	Blink *LIST_ENTRY
+}
+
 const (
 	VER_SUITE_SMALLBUSINESS            = 0x00000001
 	VER_SUITE_ENTERPRISE               = 0x00000002
@@ -1208,6 +1213,27 @@ const (
 	VER_PLATFORM_WIN32_WINDOWS = 1
 	VER_PLATFORM_WIN32_NT      = 2
 )
+
+type RTL_CRITICAL_SECTION_DEBUG struct {
+	Type                      uint16
+	CreatorBackTraceIndex     uint16
+	CriticalSection           *RTL_CRITICAL_SECTION
+	ProcessLocksList          LIST_ENTRY
+	EntryCount                uint32
+	ContentionCount           uint32
+	Flags                     uint32
+	CreatorBackTraceIndexHigh uint16
+	SpareWORD                 uint16
+}
+
+type RTL_CRITICAL_SECTION struct {
+	DebugInfo      *RTL_CRITICAL_SECTION_DEBUG
+	LockCount      int32
+	RecursionCount int32
+	OwningThread   syscall.Handle
+	LockSemaphore  syscall.Handle
+	SpinCount      uintptr
+}
 
 const (
 	EVENTLOG_SUCCESS          = 0x0000


### PR DESCRIPTION
@markbenvenuto @edaniels The Go runtime's locking primitives don't provide a `TryLock` function, and what I need it for is Windows-specific anyway, so I'll just use a Win32 critical section.