### PR TITLE
CLOUDP-17373 (Mark) Fix wrappers to work with Go 1.6

### DIFF
--- a/wrappers/msi.go
+++ b/wrappers/msi.go
@@ -158,7 +158,12 @@ var (
 )
 
 func MsiCloseHandle(handle uint32) error {
-	r1, _, _ := procMsiCloseHandle.Call(uintptr(handle))
+	r1, _, _ := syscall.Syscall(
+		procMsiCloseHandle.Addr(),
+		1,
+		uintptr(handle),
+		0,
+		0)
 	if err := syscall.Errno(r1); err != ERROR_SUCCESS {
 		return err
 	}
@@ -166,7 +171,9 @@ func MsiCloseHandle(handle uint32) error {
 }
 
 func MsiConfigureProduct(product *uint16, installLevel int32, installState int32) error {
-	r1, _, _ := procMsiConfigureProductW.Call(
+	r1, _, _ := syscall.Syscall(
+		procMsiConfigureProductW.Addr(),
+		3,
 		uintptr(unsafe.Pointer(product)),
 		uintptr(installLevel),
 		uintptr(installState))
@@ -177,11 +184,15 @@ func MsiConfigureProduct(product *uint16, installLevel int32, installState int32
 }
 
 func MsiConfigureProductEx(product *uint16, installLevel int32, installState int32, commandLine *uint16) error {
-	r1, _, _ := procMsiConfigureProductExW.Call(
+	r1, _, _ := syscall.Syscall6(
+		procMsiConfigureProductExW.Addr(),
+		4,
 		uintptr(unsafe.Pointer(product)),
 		uintptr(installLevel),
 		uintptr(installState),
-		uintptr(unsafe.Pointer(commandLine)))
+		uintptr(unsafe.Pointer(commandLine)),
+		0,
+		0)
 	if err := syscall.Errno(r1); err != ERROR_SUCCESS {
 		return err
 	}
@@ -189,7 +200,9 @@ func MsiConfigureProductEx(product *uint16, installLevel int32, installState int
 }
 
 func MsiEnableLog(logMode uint32, logFile *uint16, logAttributes uint32) error {
-	r1, _, _ := procMsiEnableLogW.Call(
+	r1, _, _ := syscall.Syscall(
+		procMsiEnableLogW.Addr(),
+		3,
 		uintptr(logMode),
 		uintptr(unsafe.Pointer(logFile)),
 		uintptr(logAttributes))
@@ -200,11 +213,15 @@ func MsiEnableLog(logMode uint32, logFile *uint16, logAttributes uint32) error {
 }
 
 func MsiEnumRelatedProducts(upgradeCode *uint16, reserved uint32, productIndex uint32, productBuf *uint16) error {
-	r1, _, _ := procMsiEnumRelatedProductsW.Call(
+	r1, _, _ := syscall.Syscall6(
+		procMsiEnumRelatedProductsW.Addr(),
+		4,
 		uintptr(unsafe.Pointer(upgradeCode)),
 		uintptr(reserved),
 		uintptr(productIndex),
-		uintptr(unsafe.Pointer(productBuf)))
+		uintptr(unsafe.Pointer(productBuf)),
+		0,
+		0)
 	if err := syscall.Errno(r1); err != ERROR_SUCCESS {
 		return err
 	}
@@ -212,20 +229,28 @@ func MsiEnumRelatedProducts(upgradeCode *uint16, reserved uint32, productIndex u
 }
 
 func MsiGetComponentPath(product *uint16, component *uint16, pathBuf *uint16, cchBuf *uint32) int32 {
-	r1, _, _ := procMsiGetComponentPathW.Call(
+	r1, _, _ := syscall.Syscall6(
+		procMsiGetComponentPathW.Addr(),
+		4,
 		uintptr(unsafe.Pointer(product)),
 		uintptr(unsafe.Pointer(component)),
 		uintptr(unsafe.Pointer(pathBuf)),
-		uintptr(unsafe.Pointer(cchBuf)))
+		uintptr(unsafe.Pointer(cchBuf)),
+		0,
+		0)
 	return int32(r1)
 }
 
 func MsiGetProductInfo(product *uint16, property *uint16, valueBuf *uint16, cchValueBuf *uint32) error {
-	r1, _, _ := procMsiGetProductInfoW.Call(
+	r1, _, _ := syscall.Syscall6(
+		procMsiGetProductInfoW.Addr(),
+		4,
 		uintptr(unsafe.Pointer(product)),
 		uintptr(unsafe.Pointer(property)),
 		uintptr(unsafe.Pointer(valueBuf)),
-		uintptr(unsafe.Pointer(cchValueBuf)))
+		uintptr(unsafe.Pointer(cchValueBuf)),
+		0,
+		0)
 	if err := syscall.Errno(r1); err != ERROR_SUCCESS {
 		return err
 	}
@@ -233,11 +258,15 @@ func MsiGetProductInfo(product *uint16, property *uint16, valueBuf *uint16, cchV
 }
 
 func MsiGetProductProperty(product uint32, property *uint16, valueBuf *uint16, cchValueBuf *uint32) error {
-	r1, _, _ := procMsiGetProductPropertyW.Call(
+	r1, _, _ := syscall.Syscall6(
+		procMsiGetProductPropertyW.Addr(),
+		4,
 		uintptr(product),
 		uintptr(unsafe.Pointer(property)),
 		uintptr(unsafe.Pointer(valueBuf)),
-		uintptr(unsafe.Pointer(cchValueBuf)))
+		uintptr(unsafe.Pointer(cchValueBuf)),
+		0,
+		0)
 	if err := syscall.Errno(r1); err != ERROR_SUCCESS {
 		return err
 	}
@@ -245,11 +274,15 @@ func MsiGetProductProperty(product uint32, property *uint16, valueBuf *uint16, c
 }
 
 func MsiGetProperty(install uint32, name *uint16, valueBuf *uint16, cchValueBuf *uint32) error {
-	r1, _, _ := procMsiGetPropertyW.Call(
+	r1, _, _ := syscall.Syscall6(
+		procMsiGetPropertyW.Addr(),
+		4,
 		uintptr(install),
 		uintptr(unsafe.Pointer(name)),
 		uintptr(unsafe.Pointer(valueBuf)),
-		uintptr(unsafe.Pointer(cchValueBuf)))
+		uintptr(unsafe.Pointer(cchValueBuf)),
+		0,
+		0)
 	if err := syscall.Errno(r1); err != ERROR_SUCCESS {
 		return err
 	}
@@ -257,9 +290,12 @@ func MsiGetProperty(install uint32, name *uint16, valueBuf *uint16, cchValueBuf 
 }
 
 func MsiInstallProduct(packagePath *uint16, commandLine *uint16) error {
-	r1, _, _ := procMsiInstallProductW.Call(
+	r1, _, _ := syscall.Syscall(
+		procMsiInstallProductW.Addr(),
+		2,
 		uintptr(unsafe.Pointer(packagePath)),
-		uintptr(unsafe.Pointer(commandLine)))
+		uintptr(unsafe.Pointer(commandLine)),
+		0)
 	if err := syscall.Errno(r1); err != ERROR_SUCCESS {
 		return err
 	}
@@ -267,9 +303,12 @@ func MsiInstallProduct(packagePath *uint16, commandLine *uint16) error {
 }
 
 func MsiOpenPackage(packagePath *uint16, product *uint32) error {
-	r1, _, _ := procMsiOpenPackageW.Call(
+	r1, _, _ := syscall.Syscall(
+		procMsiOpenPackageW.Addr(),
+		2,
 		uintptr(unsafe.Pointer(packagePath)),
-		uintptr(unsafe.Pointer(product)))
+		uintptr(unsafe.Pointer(product)),
+		0)
 	if err := syscall.Errno(r1); err != ERROR_SUCCESS {
 		return err
 	}
@@ -277,9 +316,12 @@ func MsiOpenPackage(packagePath *uint16, product *uint32) error {
 }
 
 func MsiOpenProduct(productCode *uint16, product *uint32) error {
-	r1, _, _ := procMsiOpenProductW.Call(
+	r1, _, _ := syscall.Syscall(
+		procMsiOpenProductW.Addr(),
+		2,
 		uintptr(unsafe.Pointer(productCode)),
-		uintptr(unsafe.Pointer(product)))
+		uintptr(unsafe.Pointer(product)),
+		0)
 	if err := syscall.Errno(r1); err != ERROR_SUCCESS {
 		return err
 	}
@@ -287,19 +329,32 @@ func MsiOpenProduct(productCode *uint16, product *uint32) error {
 }
 
 func MsiQueryProductState(product *uint16) int32 {
-	r1, _, _ := procMsiQueryProductStateW.Call(uintptr(unsafe.Pointer(product)))
+	r1, _, _ := syscall.Syscall(
+		procMsiQueryProductStateW.Addr(),
+		1,
+		uintptr(unsafe.Pointer(product)),
+		0,
+		0)
 	return int32(r1)
 }
 
 func MsiSetInternalUI(uiLevel int32, window *syscall.Handle) int32 {
-	r1, _, _ := procMsiSetInternalUI.Call(
+	r1, _, _ := syscall.Syscall(
+		procMsiSetInternalUI.Addr(),
+		2,
 		uintptr(uiLevel),
-		uintptr(unsafe.Pointer(window)))
+		uintptr(unsafe.Pointer(window)),
+		0)
 	return int32(r1)
 }
 
 func MsiVerifyPackage(packagePath *uint16) error {
-	r1, _, _ := procMsiVerifyPackageW.Call(uintptr(unsafe.Pointer(packagePath)))
+	r1, _, _ := syscall.Syscall(
+		procMsiVerifyPackageW.Addr(),
+		1,
+		uintptr(unsafe.Pointer(packagePath)),
+		0,
+		0)
 	if err := syscall.Errno(r1); err != ERROR_SUCCESS {
 		return err
 	}

--- a/wrappers/objbase.go
+++ b/wrappers/objbase.go
@@ -38,24 +38,32 @@ var (
 )
 
 func CoCreateInstance(clsid *GUID, outer *IUnknown, clsContext uint32, iid *GUID, object *uintptr) uint32 {
-	r1, _, _ := procCoCreateInstance.Call(
+	r1, _, _ := syscall.Syscall6(
+		procCoCreateInstance.Addr(),
+		5,
 		uintptr(unsafe.Pointer(clsid)),
 		uintptr(unsafe.Pointer(outer)),
 		uintptr(clsContext),
 		uintptr(unsafe.Pointer(iid)),
-		uintptr(unsafe.Pointer(object)))
+		uintptr(unsafe.Pointer(object)),
+		0)
 	return uint32(r1)
 }
 
 func CoInitializeEx(reserved *byte, flags uint32) uint32 {
-	r1, _, _ := procCoInitializeEx.Call(uintptr(unsafe.Pointer(reserved)), uintptr(flags))
+	r1, _, _ := syscall.Syscall(
+		procCoInitializeEx.Addr(),
+		2,
+		uintptr(unsafe.Pointer(reserved)),
+		uintptr(flags),
+		0)
 	return uint32(r1)
 }
 
 func CoTaskMemFree(mem *byte) {
-	procCoTaskMemFree.Call(uintptr(unsafe.Pointer(mem)))
+	syscall.Syscall(procCoTaskMemFree.Addr(), 1, uintptr(unsafe.Pointer(mem)), 0, 0)
 }
 
 func CoUninitialize() {
-	procCoUninitialize.Call()
+	syscall.Syscall(procCoUninitialize.Addr(), 0, 0, 0, 0)
 }

--- a/wrappers/oleauto.go
+++ b/wrappers/oleauto.go
@@ -40,33 +40,37 @@ var (
 )
 
 func SysAllocString(psz *uint16) *uint16 {
-	r1, _, _ := procSysAllocString.Call(uintptr(unsafe.Pointer(psz)))
+	r1, _, _ := syscall.Syscall(procSysAllocString.Addr(), 1, uintptr(unsafe.Pointer(psz)), 0, 0)
 	return (*uint16)(unsafe.Pointer(r1))
 }
 
 func SysFreeString(bstrString *uint16) {
-	procSysFreeString.Call(uintptr(unsafe.Pointer(bstrString)))
+	syscall.Syscall(procSysFreeString.Addr(), 1, uintptr(unsafe.Pointer(bstrString)), 0, 0)
 }
 
 func SysStringLen(bstr *uint16) uint32 {
-	r1, _, _ := procSysStringLen.Call(uintptr(unsafe.Pointer(bstr)))
+	r1, _, _ := syscall.Syscall(procSysStringLen.Addr(), 1, uintptr(unsafe.Pointer(bstr)), 0, 0)
 	return uint32(r1)
 }
 
 func VariantChangeType(dest *VARIANT, src *VARIANT, flags uint16, vt uint16) uint32 {
-	r1, _, _ := procVariantChangeType.Call(
+	r1, _, _ := syscall.Syscall6(
+		procVariantChangeType.Addr(),
+		4,
 		uintptr(unsafe.Pointer(dest)),
 		uintptr(unsafe.Pointer(src)),
 		uintptr(flags),
-		uintptr(vt))
+		uintptr(vt),
+		0,
+		0)
 	return uint32(r1)
 }
 
 func VariantClear(variant *VARIANT) uint32 {
-	r1, _, _ := procVariantClear.Call(uintptr(unsafe.Pointer(variant)))
+	r1, _, _ := syscall.Syscall(procVariantClear.Addr(), 1, uintptr(unsafe.Pointer(variant)), 0, 0)
 	return uint32(r1)
 }
 
 func VariantInit(variant *VARIANT) {
-	procVariantInit.Call(uintptr(unsafe.Pointer(variant)))
+	syscall.Syscall(procVariantInit.Addr(), 1, uintptr(unsafe.Pointer(variant)), 0, 0)
 }

--- a/wrappers/sddl.go
+++ b/wrappers/sddl.go
@@ -26,9 +26,12 @@ var (
 )
 
 func ConvertSidToStringSid(sid *SID, stringSid **uint16) error {
-	r1, _, e1 := procConvertSidToStringSidW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procConvertSidToStringSidW.Addr(),
+		2,
 		uintptr(unsafe.Pointer(sid)),
-		uintptr(unsafe.Pointer(stringSid)))
+		uintptr(unsafe.Pointer(stringSid)),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1

--- a/wrappers/shellapi.go
+++ b/wrappers/shellapi.go
@@ -67,9 +67,12 @@ var (
 )
 
 func CommandLineToArgvW(cmdLine *uint16, numArgs *int32) (**uint16, error) {
-	r1, _, e1 := procCommandLineToArgvW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procCommandLineToArgvW.Addr(),
+		2,
 		uintptr(unsafe.Pointer(cmdLine)),
-		uintptr(unsafe.Pointer(numArgs)))
+		uintptr(unsafe.Pointer(numArgs)),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return nil, e1
@@ -81,7 +84,7 @@ func CommandLineToArgvW(cmdLine *uint16, numArgs *int32) (**uint16, error) {
 }
 
 func SHFileOperation(fileOp *SHFILEOPSTRUCT) error {
-	r1, _, _ := procSHFileOperationW.Call(uintptr(unsafe.Pointer(fileOp)))
+	r1, _, _ := syscall.Syscall(procSHFileOperationW.Addr(), 1, uintptr(unsafe.Pointer(fileOp)), 0, 0)
 	if err := syscall.Errno(r1); err != ERROR_SUCCESS {
 		return err
 	}

--- a/wrappers/shlobj.go
+++ b/wrappers/shlobj.go
@@ -110,20 +110,27 @@ var (
 )
 
 func SHGetFolderPath(owner syscall.Handle, folder uint32, token syscall.Handle, flags uint32, path *uint16) uint32 {
-	r1, _, _ := procSHGetFolderPathW.Call(
+	r1, _, _ := syscall.Syscall6(
+		procSHGetFolderPathW.Addr(),
+		5,
 		uintptr(owner),
 		uintptr(folder),
 		uintptr(token),
 		uintptr(flags),
-		uintptr(unsafe.Pointer(path)))
+		uintptr(unsafe.Pointer(path)),
+		0)
 	return uint32(r1)
 }
 
 func SHGetKnownFolderPath(fid *GUID, flags uint32, token syscall.Handle, path **uint16) uint32 {
-	r1, _, _ := procSHGetKnownFolderPath.Call(
+	r1, _, _ := syscall.Syscall6(
+		procSHGetKnownFolderPath.Addr(),
+		4,
 		uintptr(unsafe.Pointer(fid)),
 		uintptr(flags),
 		uintptr(token),
-		uintptr(unsafe.Pointer(path)))
+		uintptr(unsafe.Pointer(path)),
+		0,
+		0)
 	return uint32(r1)
 }

--- a/wrappers/tlhelp32.go
+++ b/wrappers/tlhelp32.go
@@ -68,7 +68,12 @@ var (
 )
 
 func CreateToolhelp32Snapshot(flags uint32, processID uint32) (syscall.Handle, error) {
-	r1, _, e1 := procCreateToolhelp32Snapshot.Call(uintptr(flags), uintptr(processID))
+	r1, _, e1 := syscall.Syscall(
+		procCreateToolhelp32Snapshot.Addr(),
+		2,
+		uintptr(flags),
+		uintptr(processID),
+		0)
 	handle := syscall.Handle(r1)
 	if handle == INVALID_HANDLE_VALUE {
 		if e1 != ERROR_SUCCESS {
@@ -81,7 +86,12 @@ func CreateToolhelp32Snapshot(flags uint32, processID uint32) (syscall.Handle, e
 }
 
 func Module32First(snapshot syscall.Handle, me *MODULEENTRY32) error {
-	r1, _, e1 := procModule32FirstW.Call(uintptr(snapshot), uintptr(unsafe.Pointer(me)))
+	r1, _, e1 := syscall.Syscall(
+		procModule32FirstW.Addr(),
+		2,
+		uintptr(snapshot),
+		uintptr(unsafe.Pointer(me)),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -93,7 +103,12 @@ func Module32First(snapshot syscall.Handle, me *MODULEENTRY32) error {
 }
 
 func Module32Next(snapshot syscall.Handle, me *MODULEENTRY32) error {
-	r1, _, e1 := procModule32NextW.Call(uintptr(snapshot), uintptr(unsafe.Pointer(me)))
+	r1, _, e1 := syscall.Syscall(
+		procModule32NextW.Addr(),
+		2,
+		uintptr(snapshot),
+		uintptr(unsafe.Pointer(me)),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -105,7 +120,12 @@ func Module32Next(snapshot syscall.Handle, me *MODULEENTRY32) error {
 }
 
 func Process32First(snapshot syscall.Handle, pe *PROCESSENTRY32) error {
-	r1, _, e1 := procProcess32FirstW.Call(uintptr(snapshot), uintptr(unsafe.Pointer(pe)))
+	r1, _, e1 := syscall.Syscall(
+		procProcess32FirstW.Addr(),
+		2,
+		uintptr(snapshot),
+		uintptr(unsafe.Pointer(pe)),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -117,7 +137,12 @@ func Process32First(snapshot syscall.Handle, pe *PROCESSENTRY32) error {
 }
 
 func Process32Next(snapshot syscall.Handle, pe *PROCESSENTRY32) error {
-	r1, _, e1 := procProcess32NextW.Call(uintptr(snapshot), uintptr(unsafe.Pointer(pe)))
+	r1, _, e1 := syscall.Syscall(
+		procProcess32NextW.Addr(),
+		2,
+		uintptr(snapshot),
+		uintptr(unsafe.Pointer(pe)),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1

--- a/wrappers/winbase.go
+++ b/wrappers/winbase.go
@@ -341,7 +341,12 @@ var (
 )
 
 func AssignProcessToJobObject(job syscall.Handle, process syscall.Handle) error {
-	r1, _, e1 := procAssignProcessToJobObject.Call(uintptr(job), uintptr(process))
+	r1, _, e1 := syscall.Syscall(
+		procAssignProcessToJobObject.Addr(),
+		2,
+		uintptr(job),
+		uintptr(process),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -359,9 +364,12 @@ func BeginUpdateResource(fileName *uint16, deleteExistingResources bool) (syscal
 	} else {
 		deleteExistingResourcesRaw = 0
 	}
-	r1, _, e1 := procBeginUpdateResourceW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procBeginUpdateResourceW.Addr(),
+		2,
 		uintptr(unsafe.Pointer(fileName)),
-		uintptr(deleteExistingResourcesRaw))
+		uintptr(deleteExistingResourcesRaw),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return 0, e1
@@ -373,7 +381,7 @@ func BeginUpdateResource(fileName *uint16, deleteExistingResources bool) (syscal
 }
 
 func CloseHandle(object syscall.Handle) error {
-	r1, _, e1 := procCloseHandle.Call(uintptr(object))
+	r1, _, e1 := syscall.Syscall(procCloseHandle.Addr(), 1, uintptr(object), 0, 0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -391,7 +399,9 @@ func CopyFile(existingFileName *uint16, newFileName *uint16, failIfExists bool) 
 	} else {
 		failIfExistsRaw = 0
 	}
-	r1, _, e1 := procCopyFileW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procCopyFileW.Addr(),
+		3,
 		uintptr(unsafe.Pointer(existingFileName)),
 		uintptr(unsafe.Pointer(newFileName)),
 		uintptr(failIfExistsRaw))
@@ -406,14 +416,18 @@ func CopyFile(existingFileName *uint16, newFileName *uint16, failIfExists bool) 
 }
 
 func CreateFile(fileName *uint16, desiredAccess uint32, shareMode uint32, securityAttributes *SECURITY_ATTRIBUTES, creationDisposition uint32, flagsAndAttributes uint32, templateFile syscall.Handle) (syscall.Handle, error) {
-	r1, _, e1 := procCreateFileW.Call(
+	r1, _, e1 := syscall.Syscall9(
+		procCreateFileW.Addr(),
+		7,
 		uintptr(unsafe.Pointer(fileName)),
 		uintptr(desiredAccess),
 		uintptr(shareMode),
 		uintptr(unsafe.Pointer(securityAttributes)),
 		uintptr(creationDisposition),
 		uintptr(flagsAndAttributes),
-		uintptr(templateFile))
+		uintptr(templateFile),
+		0,
+		0)
 	handle := syscall.Handle(r1)
 	if handle == INVALID_HANDLE_VALUE {
 		if e1 != ERROR_SUCCESS {
@@ -426,9 +440,12 @@ func CreateFile(fileName *uint16, desiredAccess uint32, shareMode uint32, securi
 }
 
 func CreateJobObject(jobAttributes *SECURITY_ATTRIBUTES, name *uint16) (syscall.Handle, error) {
-	r1, _, e1 := procCreateJobObjectW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procCreateJobObjectW.Addr(),
+		2,
 		uintptr(unsafe.Pointer(jobAttributes)),
-		uintptr(unsafe.Pointer(name)))
+		uintptr(unsafe.Pointer(name)),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return 0, e1
@@ -446,7 +463,9 @@ func CreateProcess(applicationName *uint16, commandLine *uint16, processAttribut
 	} else {
 		inheritHandlesRaw = 0
 	}
-	r1, _, e1 := procCreateProcessW.Call(
+	r1, _, e1 := syscall.Syscall12(
+		procCreateProcessW.Addr(),
+		10,
 		uintptr(unsafe.Pointer(applicationName)),
 		uintptr(unsafe.Pointer(commandLine)),
 		uintptr(unsafe.Pointer(processAttributes)),
@@ -456,7 +475,9 @@ func CreateProcess(applicationName *uint16, commandLine *uint16, processAttribut
 		uintptr(unsafe.Pointer(environment)),
 		uintptr(unsafe.Pointer(currentDirectory)),
 		uintptr(unsafe.Pointer(startupInfo)),
-		uintptr(unsafe.Pointer(processInformation)))
+		uintptr(unsafe.Pointer(processInformation)),
+		0,
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -468,7 +489,9 @@ func CreateProcess(applicationName *uint16, commandLine *uint16, processAttribut
 }
 
 func CreateSymbolicLink(symlinkFileName *uint16, targetFileName *uint16, flags uint32) error {
-	r1, _, e1 := procCreateSymbolicLinkW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procCreateSymbolicLinkW.Addr(),
+		3,
 		uintptr(unsafe.Pointer(symlinkFileName)),
 		uintptr(unsafe.Pointer(targetFileName)),
 		uintptr(flags))
@@ -483,11 +506,11 @@ func CreateSymbolicLink(symlinkFileName *uint16, targetFileName *uint16, flags u
 }
 
 func DeleteCriticalSection(criticalSection *CRITICAL_SECTION) {
-	procDeleteCriticalSection.Call(uintptr(unsafe.Pointer(criticalSection)))
+	syscall.Syscall(procDeleteCriticalSection.Addr(), 1, uintptr(unsafe.Pointer(criticalSection)), 0, 0)
 }
 
 func DeleteFile(fileName *uint16) error {
-	r1, _, e1 := procDeleteFileW.Call(uintptr(unsafe.Pointer(fileName)))
+	r1, _, e1 := syscall.Syscall(procDeleteFileW.Addr(), 1, uintptr(unsafe.Pointer(fileName)), 0, 0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -499,7 +522,9 @@ func DeleteFile(fileName *uint16) error {
 }
 
 func DeviceIoControl(device syscall.Handle, ioControlCode uint32, inBuffer *byte, inBufferSize uint32, outBuffer *byte, outBufferSize uint32, bytesReturned *uint32, overlapped *syscall.Overlapped) error {
-	r1, _, e1 := procDeviceIoControl.Call(
+	r1, _, e1 := syscall.Syscall9(
+		procDeviceIoControl.Addr(),
+		8,
 		uintptr(device),
 		uintptr(ioControlCode),
 		uintptr(unsafe.Pointer(inBuffer)),
@@ -507,7 +532,8 @@ func DeviceIoControl(device syscall.Handle, ioControlCode uint32, inBuffer *byte
 		uintptr(unsafe.Pointer(outBuffer)),
 		uintptr(outBufferSize),
 		uintptr(unsafe.Pointer(bytesReturned)),
-		uintptr(unsafe.Pointer(overlapped)))
+		uintptr(unsafe.Pointer(overlapped)),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -525,9 +551,12 @@ func EndUpdateResource(update syscall.Handle, discard bool) error {
 	} else {
 		discardRaw = 0
 	}
-	r1, _, e1 := procEndUpdateResourceW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procEndUpdateResourceW.Addr(),
+		2,
 		uintptr(update),
-		uintptr(discardRaw))
+		uintptr(discardRaw),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -539,11 +568,13 @@ func EndUpdateResource(update syscall.Handle, discard bool) error {
 }
 
 func EnterCriticalSection(criticalSection *CRITICAL_SECTION) {
-	procEnterCriticalSection.Call(uintptr(unsafe.Pointer(criticalSection)))
+	syscall.Syscall(procEnterCriticalSection.Addr(), 1, uintptr(unsafe.Pointer(criticalSection)), 0, 0)
 }
 
 func ExpandEnvironmentStrings(src *uint16, dst *uint16, size uint32) (uint32, error) {
-	r1, _, e1 := procExpandEnvironmentStringsW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procExpandEnvironmentStringsW.Addr(),
+		3,
 		uintptr(unsafe.Pointer(src)),
 		uintptr(unsafe.Pointer(dst)),
 		uintptr(size))
@@ -558,7 +589,7 @@ func ExpandEnvironmentStrings(src *uint16, dst *uint16, size uint32) (uint32, er
 }
 
 func FindClose(findFile syscall.Handle) error {
-	r1, _, e1 := procFindClose.Call(uintptr(findFile))
+	r1, _, e1 := syscall.Syscall(procFindClose.Addr(), 1, uintptr(findFile), 0, 0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -570,9 +601,12 @@ func FindClose(findFile syscall.Handle) error {
 }
 
 func FindFirstFile(fileName *uint16, findFileData *WIN32_FIND_DATA) (syscall.Handle, error) {
-	r1, _, e1 := procFindFirstFileW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procFindFirstFileW.Addr(),
+		2,
 		uintptr(unsafe.Pointer(fileName)),
-		uintptr(unsafe.Pointer(findFileData)))
+		uintptr(unsafe.Pointer(findFileData)),
+		0)
 	handle := syscall.Handle(r1)
 	if handle == INVALID_HANDLE_VALUE {
 		if e1 != ERROR_SUCCESS {
@@ -585,7 +619,12 @@ func FindFirstFile(fileName *uint16, findFileData *WIN32_FIND_DATA) (syscall.Han
 }
 
 func FindNextFile(findFile syscall.Handle, findFileData *WIN32_FIND_DATA) error {
-	r1, _, e1 := procFindNextFileW.Call(uintptr(findFile), uintptr(unsafe.Pointer(findFileData)))
+	r1, _, e1 := syscall.Syscall(
+		procFindNextFileW.Addr(),
+		2,
+		uintptr(findFile),
+		uintptr(unsafe.Pointer(findFileData)),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -597,16 +636,20 @@ func FindNextFile(findFile syscall.Handle, findFileData *WIN32_FIND_DATA) error 
 }
 
 func FormatMessage(flags uint32, source uintptr, messageId uint32, languageId uint32, buffer *uint16, size uint32, arguments *byte) (uint32, error) {
-	r1, _, e1 := procFormatMessageW.Call(
+	r1, _, e1 := syscall.Syscall9(
+		procFormatMessageW.Addr(),
+		7,
 		uintptr(flags),
 		source,
 		uintptr(messageId),
 		uintptr(languageId),
 		uintptr(unsafe.Pointer(buffer)),
 		uintptr(size),
-		uintptr(unsafe.Pointer(arguments)))
+		uintptr(unsafe.Pointer(arguments)),
+		0,
+		0)
 	if r1 == 0 {
-		if e1.(syscall.Errno) != 0 {
+		if e1 != 0 {
 			return 0, e1
 		} else {
 			return 0, syscall.EINVAL
@@ -616,7 +659,12 @@ func FormatMessage(flags uint32, source uintptr, messageId uint32, languageId ui
 }
 
 func FreeEnvironmentStrings(environmentBlock *uint16) error {
-	r1, _, e1 := procFreeEnvironmentStringsW.Call(uintptr(unsafe.Pointer(environmentBlock)))
+	r1, _, e1 := syscall.Syscall(
+		procFreeEnvironmentStringsW.Addr(),
+		1,
+		uintptr(unsafe.Pointer(environmentBlock)),
+		0,
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -628,7 +676,7 @@ func FreeEnvironmentStrings(environmentBlock *uint16) error {
 }
 
 func FreeLibrary(module syscall.Handle) error {
-	r1, _, e1 := procFreeLibrary.Call(uintptr(module))
+	r1, _, e1 := syscall.Syscall(procFreeLibrary.Addr(), 1, uintptr(module), 0, 0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -640,9 +688,12 @@ func FreeLibrary(module syscall.Handle) error {
 }
 
 func GetCompressedFileSize(fileName *uint16, fileSizeHigh *uint32) (uint32, error) {
-	r1, _, e1 := procGetCompressedFileSizeW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procGetCompressedFileSizeW.Addr(),
+		2,
 		uintptr(unsafe.Pointer(fileName)),
-		uintptr(unsafe.Pointer(fileSizeHigh)))
+		uintptr(unsafe.Pointer(fileSizeHigh)),
+		0)
 	if r1 == INVALID_FILE_SIZE {
 		if e1 != ERROR_SUCCESS {
 			return uint32(r1), e1
@@ -654,7 +705,9 @@ func GetCompressedFileSize(fileName *uint16, fileSizeHigh *uint32) (uint32, erro
 }
 
 func GetComputerNameEx(nameType uint32, buffer *uint16, size *uint32) error {
-	r1, _, e1 := procGetComputerNameExW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procGetComputerNameExW.Addr(),
+		3,
 		uintptr(nameType),
 		uintptr(unsafe.Pointer(buffer)),
 		uintptr(unsafe.Pointer(size)))
@@ -669,22 +722,25 @@ func GetComputerNameEx(nameType uint32, buffer *uint16, size *uint32) error {
 }
 
 func GetCurrentProcess() syscall.Handle {
-	r1, _, _ := procGetCurrentProcess.Call()
+	r1, _, _ := syscall.Syscall(procGetCurrentProcess.Addr(), 0, 0, 0, 0)
 	return syscall.Handle(r1)
 }
 
 func GetCurrentThread() syscall.Handle {
-	r1, _, _ := procGetCurrentThread.Call()
+	r1, _, _ := syscall.Syscall(procGetCurrentThread.Addr(), 0, 0, 0, 0)
 	return syscall.Handle(r1)
 }
 
 func GetDiskFreeSpace(rootPathName *uint16, sectorsPerCluster *uint32, bytesPerSector *uint32, numberOfFreeClusters *uint32, totalNumberOfClusters *uint32) error {
-	r1, _, e1 := procGetDiskFreeSpaceW.Call(
+	r1, _, e1 := syscall.Syscall6(
+		procGetDiskFreeSpaceW.Addr(),
+		5,
 		uintptr(unsafe.Pointer(rootPathName)),
 		uintptr(unsafe.Pointer(sectorsPerCluster)),
 		uintptr(unsafe.Pointer(bytesPerSector)),
 		uintptr(unsafe.Pointer(numberOfFreeClusters)),
-		uintptr(unsafe.Pointer(totalNumberOfClusters)))
+		uintptr(unsafe.Pointer(totalNumberOfClusters)),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -696,11 +752,15 @@ func GetDiskFreeSpace(rootPathName *uint16, sectorsPerCluster *uint32, bytesPerS
 }
 
 func GetDiskFreeSpaceEx(directoryName *uint16, freeBytesAvailable *uint64, totalNumberOfBytes *uint64, totalNumberOfFreeBytes *uint64) error {
-	r1, _, e1 := procGetDiskFreeSpaceExW.Call(
+	r1, _, e1 := syscall.Syscall6(
+		procGetDiskFreeSpaceExW.Addr(),
+		4,
 		uintptr(unsafe.Pointer(directoryName)),
 		uintptr(unsafe.Pointer(freeBytesAvailable)),
 		uintptr(unsafe.Pointer(totalNumberOfBytes)),
-		uintptr(unsafe.Pointer(totalNumberOfFreeBytes)))
+		uintptr(unsafe.Pointer(totalNumberOfFreeBytes)),
+		0,
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -712,12 +772,12 @@ func GetDiskFreeSpaceEx(directoryName *uint16, freeBytesAvailable *uint64, total
 }
 
 func GetDriveType(rootPathName *uint16) uint32 {
-	r1, _, _ := procGetDriveTypeW.Call(uintptr(unsafe.Pointer(rootPathName)))
+	r1, _, _ := syscall.Syscall(procGetDriveTypeW.Addr(), 1, uintptr(unsafe.Pointer(rootPathName)), 0, 0)
 	return uint32(r1)
 }
 
 func GetEnvironmentStrings() (*uint16, error) {
-	r1, _, e1 := procGetEnvironmentStringsW.Call()
+	r1, _, e1 := syscall.Syscall(procGetEnvironmentStringsW.Addr(), 0, 0, 0, 0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return nil, e1
@@ -729,7 +789,9 @@ func GetEnvironmentStrings() (*uint16, error) {
 }
 
 func GetEnvironmentVariable(name *uint16, buffer *uint16, size uint32) (uint32, error) {
-	r1, _, e1 := procGetEnvironmentVariableW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procGetEnvironmentVariableW.Addr(),
+		3,
 		uintptr(unsafe.Pointer(name)),
 		uintptr(unsafe.Pointer(buffer)),
 		uintptr(size))
@@ -744,7 +806,7 @@ func GetEnvironmentVariable(name *uint16, buffer *uint16, size uint32) (uint32, 
 }
 
 func GetFileAttributes(fileName *uint16) (uint32, error) {
-	r1, _, e1 := procGetFileAttributesW.Call(uintptr(unsafe.Pointer(fileName)))
+	r1, _, e1 := syscall.Syscall(procGetFileAttributesW.Addr(), 1, uintptr(unsafe.Pointer(fileName)), 0, 0)
 	if r1 == INVALID_FILE_ATTRIBUTES {
 		if e1 != ERROR_SUCCESS {
 			return uint32(r1), e1
@@ -756,9 +818,12 @@ func GetFileAttributes(fileName *uint16) (uint32, error) {
 }
 
 func GetFileSize(file syscall.Handle, fileSizeHigh *uint32) (uint32, error) {
-	r1, _, e1 := procGetFileSize.Call(
+	r1, _, e1 := syscall.Syscall(
+		procGetFileSize.Addr(),
+		2,
 		uintptr(file),
-		uintptr(unsafe.Pointer(fileSizeHigh)))
+		uintptr(unsafe.Pointer(fileSizeHigh)),
+		0)
 	if r1 == INVALID_FILE_SIZE {
 		if e1 != ERROR_SUCCESS {
 			return uint32(r1), e1
@@ -770,7 +835,9 @@ func GetFileSize(file syscall.Handle, fileSizeHigh *uint32) (uint32, error) {
 }
 
 func GetModuleFileName(module syscall.Handle, filename *uint16, size uint32) (uint32, error) {
-	r1, _, e1 := procGetModuleFileNameW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procGetModuleFileNameW.Addr(),
+		3,
 		uintptr(module),
 		uintptr(unsafe.Pointer(filename)),
 		uintptr(size))
@@ -787,12 +854,15 @@ func GetModuleFileName(module syscall.Handle, filename *uint16, size uint32) (ui
 }
 
 func GetProcessTimes(hProcess syscall.Handle, creationTime, exitTime, kernelTime, userTime *FILETIME) error {
-	r1, _, e1 := procGetProcessTimes.Call(
+	r1, _, e1 := syscall.Syscall6(
+		procGetProcessTimes.Addr(),
+		5,
 		uintptr(hProcess),
 		uintptr(unsafe.Pointer(creationTime)),
 		uintptr(unsafe.Pointer(exitTime)),
 		uintptr(unsafe.Pointer(kernelTime)),
-		uintptr(unsafe.Pointer(userTime)))
+		uintptr(unsafe.Pointer(userTime)),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -804,7 +874,7 @@ func GetProcessTimes(hProcess syscall.Handle, creationTime, exitTime, kernelTime
 }
 
 func GetStdHandle(stdHandle uint32) (syscall.Handle, error) {
-	r1, _, e1 := procGetStdHandle.Call(uintptr(stdHandle))
+	r1, _, e1 := syscall.Syscall(procGetStdHandle.Addr(), 1, uintptr(stdHandle), 0, 0)
 	handle := (syscall.Handle)(r1)
 	if handle == INVALID_HANDLE_VALUE {
 		if e1 != ERROR_SUCCESS {
@@ -817,9 +887,12 @@ func GetStdHandle(stdHandle uint32) (syscall.Handle, error) {
 }
 
 func GetSystemDirectory(buffer *uint16, size uint32) (uint32, error) {
-	r1, _, e1 := procGetSystemDirectoryW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procGetSystemDirectoryW.Addr(),
+		2,
 		uintptr(unsafe.Pointer(buffer)),
-		uintptr(size))
+		uintptr(size),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return 0, e1
@@ -831,15 +904,17 @@ func GetSystemDirectory(buffer *uint16, size uint32) (uint32, error) {
 }
 
 func GetSystemInfo(systemInfo *SYSTEM_INFO) {
-	procGetSystemInfo.Call(uintptr(unsafe.Pointer(systemInfo)))
+	syscall.Syscall(procGetSystemInfo.Addr(), 1, uintptr(unsafe.Pointer(systemInfo)), 0, 0)
 }
 
 func GetSystemTimeAsFileTime(systemTimeAsFileTime *FILETIME) {
-	procGetSystemTimeAsFileTime.Call(uintptr(unsafe.Pointer(systemTimeAsFileTime)))
+	syscall.Syscall(procGetSystemTimeAsFileTime.Addr(), 1, uintptr(unsafe.Pointer(systemTimeAsFileTime)), 0, 0)
 }
 
 func GetSystemTimes(idleTime, kernelTime, userTime *FILETIME) error {
-	r1, _, e1 := procGetSystemTimes.Call(
+	r1, _, e1 := syscall.Syscall(
+		procGetSystemTimes.Addr(),
+		3,
 		uintptr(unsafe.Pointer(idleTime)),
 		uintptr(unsafe.Pointer(kernelTime)),
 		uintptr(unsafe.Pointer(userTime)))
@@ -854,9 +929,12 @@ func GetSystemTimes(idleTime, kernelTime, userTime *FILETIME) error {
 }
 
 func GetSystemWindowsDirectory(buffer *uint16, size uint32) (uint32, error) {
-	r1, _, e1 := procGetSystemWindowsDirectoryW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procGetSystemWindowsDirectoryW.Addr(),
+		2,
 		uintptr(unsafe.Pointer(buffer)),
-		uintptr(size))
+		uintptr(size),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return 0, e1
@@ -868,9 +946,12 @@ func GetSystemWindowsDirectory(buffer *uint16, size uint32) (uint32, error) {
 }
 
 func GetSystemWow64Directory(buffer *uint16, size uint32) (uint32, error) {
-	r1, _, e1 := procGetSystemWow64DirectoryW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procGetSystemWow64DirectoryW.Addr(),
+		2,
 		uintptr(unsafe.Pointer(buffer)),
-		uintptr(size))
+		uintptr(size),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return 0, e1
@@ -882,11 +963,15 @@ func GetSystemWow64Directory(buffer *uint16, size uint32) (uint32, error) {
 }
 
 func GetTempFileName(pathName *uint16, prefixString *uint16, unique uint32, tempFileName *uint16) (uint32, error) {
-	r1, _, e1 := procGetTempFileNameW.Call(
+	r1, _, e1 := syscall.Syscall6(
+		procGetTempFileNameW.Addr(),
+		4,
 		uintptr(unsafe.Pointer(pathName)),
 		uintptr(unsafe.Pointer(prefixString)),
 		uintptr(unique),
-		uintptr(unsafe.Pointer(tempFileName)))
+		uintptr(unsafe.Pointer(tempFileName)),
+		0,
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return 0, e1
@@ -898,9 +983,12 @@ func GetTempFileName(pathName *uint16, prefixString *uint16, unique uint32, temp
 }
 
 func GetTempPath(bufferLength uint32, buffer *uint16) (uint32, error) {
-	r1, _, e1 := procGetTempPathW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procGetTempPathW.Addr(),
+		2,
 		uintptr(bufferLength),
-		uintptr(unsafe.Pointer(buffer)))
+		uintptr(unsafe.Pointer(buffer)),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return 0, e1
@@ -912,7 +1000,7 @@ func GetTempPath(bufferLength uint32, buffer *uint16) (uint32, error) {
 }
 
 func GetVersionEx(osvi *OSVERSIONINFOEX) error {
-	r1, _, e1 := procGetVersionExW.Call(uintptr(unsafe.Pointer(osvi)))
+	r1, _, e1 := syscall.Syscall(procGetVersionExW.Addr(), 1, uintptr(unsafe.Pointer(osvi)), 0, 0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -924,7 +1012,9 @@ func GetVersionEx(osvi *OSVERSIONINFOEX) error {
 }
 
 func GetVolumeInformation(rootPathName *uint16, volumeNameBuffer *uint16, volumeNameSize uint32, volumeSerialNumber *uint32, maximumComponentLength *uint32, fileSystemFlags *uint32, fileSystemNameBuffer *uint16, fileSystemNameSize uint32) error {
-	r1, _, e1 := procGetVolumeInformationW.Call(
+	r1, _, e1 := syscall.Syscall9(
+		procGetVolumeInformationW.Addr(),
+		8,
 		uintptr(unsafe.Pointer(rootPathName)),
 		uintptr(unsafe.Pointer(volumeNameBuffer)),
 		uintptr(volumeNameSize),
@@ -932,7 +1022,8 @@ func GetVolumeInformation(rootPathName *uint16, volumeNameBuffer *uint16, volume
 		uintptr(unsafe.Pointer(maximumComponentLength)),
 		uintptr(unsafe.Pointer(fileSystemFlags)),
 		uintptr(unsafe.Pointer(fileSystemNameBuffer)),
-		uintptr(fileSystemNameSize))
+		uintptr(fileSystemNameSize),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -944,7 +1035,9 @@ func GetVolumeInformation(rootPathName *uint16, volumeNameBuffer *uint16, volume
 }
 
 func GetVolumeNameForVolumeMountPoint(volumeMountPoint *uint16, volumeName *uint16, bufferLength uint32) error {
-	r1, _, e1 := procGetVolumeNameForVolumeMountPointW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procGetVolumeNameForVolumeMountPointW.Addr(),
+		3,
 		uintptr(unsafe.Pointer(volumeMountPoint)),
 		uintptr(unsafe.Pointer(volumeName)),
 		uintptr(bufferLength))
@@ -959,7 +1052,9 @@ func GetVolumeNameForVolumeMountPoint(volumeMountPoint *uint16, volumeName *uint
 }
 
 func GetVolumePathName(fileName *uint16, volumePathName *uint16, bufferLength uint32) error {
-	r1, _, e1 := procGetVolumePathNameW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procGetVolumePathNameW.Addr(),
+		3,
 		uintptr(unsafe.Pointer(fileName)),
 		uintptr(unsafe.Pointer(volumePathName)),
 		uintptr(bufferLength))
@@ -974,9 +1069,12 @@ func GetVolumePathName(fileName *uint16, volumePathName *uint16, bufferLength ui
 }
 
 func GetWindowsDirectory(buffer *uint16, size uint32) (uint32, error) {
-	r1, _, e1 := procGetWindowsDirectoryW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procGetWindowsDirectoryW.Addr(),
+		2,
 		uintptr(unsafe.Pointer(buffer)),
-		uintptr(size))
+		uintptr(size),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return 0, e1
@@ -988,12 +1086,14 @@ func GetWindowsDirectory(buffer *uint16, size uint32) (uint32, error) {
 }
 
 func InitializeCriticalSection(criticalSection *CRITICAL_SECTION) {
-	procInitializeCriticalSection.Call(uintptr(unsafe.Pointer(criticalSection)))
+	syscall.Syscall(procInitializeCriticalSection.Addr(), 1, uintptr(unsafe.Pointer(criticalSection)), 0, 0)
 }
 
 func IsProcessInJob(processHandle syscall.Handle, jobHandle syscall.Handle, result *bool) error {
 	var resultRaw int32
-	r1, _, e1 := procIsProcessInJob.Call(
+	r1, _, e1 := syscall.Syscall(
+		procIsProcessInJob.Addr(),
+		3,
 		uintptr(processHandle),
 		uintptr(jobHandle),
 		uintptr(unsafe.Pointer(&resultRaw)))
@@ -1011,11 +1111,11 @@ func IsProcessInJob(processHandle syscall.Handle, jobHandle syscall.Handle, resu
 }
 
 func LeaveCriticalSection(criticalSection *CRITICAL_SECTION) {
-	procLeaveCriticalSection.Call(uintptr(unsafe.Pointer(criticalSection)))
+	syscall.Syscall(procLeaveCriticalSection.Addr(), 1, uintptr(unsafe.Pointer(criticalSection)), 0, 0)
 }
 
 func LoadLibrary(fileName *uint16) (syscall.Handle, error) {
-	r1, _, e1 := procLoadLibraryW.Call(uintptr(unsafe.Pointer(fileName)))
+	r1, _, e1 := syscall.Syscall(procLoadLibraryW.Addr(), 1, uintptr(unsafe.Pointer(fileName)), 0, 0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return 0, e1
@@ -1028,9 +1128,9 @@ func LoadLibrary(fileName *uint16) (syscall.Handle, error) {
 
 func LocalFree(mem syscall.Handle) (syscall.Handle, error) {
 	// LocalFree returns NULL to indicate success!
-	r1, _, e1 := procLocalFree.Call(uintptr(mem))
+	r1, _, e1 := syscall.Syscall(procLocalFree.Addr(), 1, uintptr(mem), 0, 0)
 	if r1 != 0 {
-		if e1.(syscall.Errno) != 0 {
+		if e1 != 0 {
 			return syscall.Handle(r1), e1
 		} else {
 			return syscall.Handle(r1), syscall.EINVAL
@@ -1040,9 +1140,12 @@ func LocalFree(mem syscall.Handle) (syscall.Handle, error) {
 }
 
 func MoveFile(existingFileName *uint16, newFileName *uint16) error {
-	r1, _, e1 := procMoveFileW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procMoveFileW.Addr(),
+		2,
 		uintptr(unsafe.Pointer(existingFileName)),
-		uintptr(unsafe.Pointer(newFileName)))
+		uintptr(unsafe.Pointer(newFileName)),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -1054,7 +1157,9 @@ func MoveFile(existingFileName *uint16, newFileName *uint16) error {
 }
 
 func MoveFileEx(existingFileName *uint16, newFileName *uint16, flags uint32) error {
-	r1, _, e1 := procMoveFileExW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procMoveFileExW.Addr(),
+		3,
 		uintptr(unsafe.Pointer(existingFileName)),
 		uintptr(unsafe.Pointer(newFileName)),
 		uintptr(flags))
@@ -1075,7 +1180,9 @@ func OpenJobObject(desiredAccess uint32, inheritHandle bool, name *uint16) (sysc
 	} else {
 		inheritHandleRaw = 0
 	}
-	r1, _, e1 := procOpenJobObjectW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procOpenJobObjectW.Addr(),
+		3,
 		uintptr(desiredAccess),
 		uintptr(inheritHandleRaw),
 		uintptr(unsafe.Pointer(name)))
@@ -1096,7 +1203,9 @@ func OpenProcess(desiredAccess uint32, inheritHandle bool, processId uint32) (sy
 	} else {
 		inheritHandleRaw = 0
 	}
-	r1, _, e1 := procOpenProcess.Call(
+	r1, _, e1 := syscall.Syscall(
+		procOpenProcess.Addr(),
+		3,
 		uintptr(desiredAccess),
 		uintptr(inheritHandleRaw),
 		uintptr(processId))
@@ -1111,11 +1220,15 @@ func OpenProcess(desiredAccess uint32, inheritHandle bool, processId uint32) (sy
 }
 
 func QueryFullProcessImageName(process syscall.Handle, flags uint32, exeName *uint16, size *uint32) error {
-	r1, _, e1 := procQueryFullProcessImageNameW.Call(
+	r1, _, e1 := syscall.Syscall6(
+		procQueryFullProcessImageNameW.Addr(),
+		4,
 		uintptr(process),
 		uintptr(flags),
 		uintptr(unsafe.Pointer(exeName)),
-		uintptr(unsafe.Pointer(size)))
+		uintptr(unsafe.Pointer(size)),
+		0,
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -1127,12 +1240,15 @@ func QueryFullProcessImageName(process syscall.Handle, flags uint32, exeName *ui
 }
 
 func QueryInformationJobObject(job syscall.Handle, jobObjectInfoClass int32, jobObjectInfo *byte, jobObjectInfoLength uint32, returnLength *uint32) error {
-	r1, _, e1 := procQueryInformationJobObject.Call(
+	r1, _, e1 := syscall.Syscall6(
+		procQueryInformationJobObject.Addr(),
+		5,
 		uintptr(job),
 		uintptr(jobObjectInfoClass),
 		uintptr(unsafe.Pointer(jobObjectInfo)),
 		uintptr(jobObjectInfoLength),
-		uintptr(unsafe.Pointer(returnLength)))
+		uintptr(unsafe.Pointer(returnLength)),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -1144,12 +1260,15 @@ func QueryInformationJobObject(job syscall.Handle, jobObjectInfoClass int32, job
 }
 
 func ReadFile(file syscall.Handle, buffer *byte, numberOfBytesToRead uint32, numberOfBytesRead *uint32, overlapped *OVERLAPPED) error {
-	r1, _, e1 := procReadFile.Call(
+	r1, _, e1 := syscall.Syscall6(
+		procReadFile.Addr(),
+		5,
 		uintptr(file),
 		uintptr(unsafe.Pointer(buffer)),
 		uintptr(numberOfBytesToRead),
 		uintptr(unsafe.Pointer(numberOfBytesRead)),
-		uintptr(unsafe.Pointer(overlapped)))
+		uintptr(unsafe.Pointer(overlapped)),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -1161,12 +1280,15 @@ func ReadFile(file syscall.Handle, buffer *byte, numberOfBytesToRead uint32, num
 }
 
 func ReadProcessMemory(process syscall.Handle, baseAddress uintptr, buffer *byte, size uint32, numberOfBytesRead *uint32) error {
-	r1, _, e1 := procReadProcessMemory.Call(
+	r1, _, e1 := syscall.Syscall6(
+		procReadProcessMemory.Addr(),
+		5,
 		uintptr(process),
 		baseAddress,
 		uintptr(unsafe.Pointer(buffer)),
 		uintptr(size),
-		uintptr(unsafe.Pointer(numberOfBytesRead)))
+		uintptr(unsafe.Pointer(numberOfBytesRead)),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -1178,9 +1300,12 @@ func ReadProcessMemory(process syscall.Handle, baseAddress uintptr, buffer *byte
 }
 
 func SetEnvironmentVariable(name *uint16, value *uint16) error {
-	r1, _, e1 := procSetEnvironmentVariableW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procSetEnvironmentVariableW.Addr(),
+		2,
 		uintptr(unsafe.Pointer(name)),
-		uintptr(unsafe.Pointer(value)))
+		uintptr(unsafe.Pointer(value)),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -1192,9 +1317,12 @@ func SetEnvironmentVariable(name *uint16, value *uint16) error {
 }
 
 func SetFileAttributes(fileName *uint16, fileAttributes uint32) error {
-	r1, _, e1 := procSetFileAttributesW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procSetFileAttributesW.Addr(),
+		2,
 		uintptr(unsafe.Pointer(fileName)),
-		uintptr(fileAttributes))
+		uintptr(fileAttributes),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -1206,11 +1334,15 @@ func SetFileAttributes(fileName *uint16, fileAttributes uint32) error {
 }
 
 func SetFileTime(file syscall.Handle, creationTime *FILETIME, lastAccessTime *FILETIME, lastWriteTime *FILETIME) error {
-	r1, _, e1 := procSetFileTime.Call(
+	r1, _, e1 := syscall.Syscall6(
+		procSetFileTime.Addr(),
+		4,
 		uintptr(file),
 		uintptr(unsafe.Pointer(creationTime)),
 		uintptr(unsafe.Pointer(lastAccessTime)),
-		uintptr(unsafe.Pointer(lastWriteTime)))
+		uintptr(unsafe.Pointer(lastWriteTime)),
+		0,
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -1222,11 +1354,15 @@ func SetFileTime(file syscall.Handle, creationTime *FILETIME, lastAccessTime *FI
 }
 
 func SetInformationJobObject(job syscall.Handle, jobObjectInfoClass int32, jobObjectInfo *byte, jobObjectInfoLength uint32) error {
-	r1, _, e1 := procSetInformationJobObject.Call(
+	r1, _, e1 := syscall.Syscall6(
+		procSetInformationJobObject.Addr(),
+		4,
 		uintptr(job),
 		uintptr(jobObjectInfoClass),
 		uintptr(unsafe.Pointer(jobObjectInfo)),
-		uintptr(jobObjectInfoLength))
+		uintptr(jobObjectInfoLength),
+		0,
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -1238,7 +1374,12 @@ func SetInformationJobObject(job syscall.Handle, jobObjectInfoClass int32, jobOb
 }
 
 func SetStdHandle(stdHandle uint32, handle syscall.Handle) error {
-	r1, _, e1 := procSetStdHandle.Call(uintptr(stdHandle), uintptr(handle))
+	r1, _, e1 := syscall.Syscall(
+		procSetStdHandle.Addr(),
+		2,
+		uintptr(stdHandle),
+		uintptr(handle),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -1250,7 +1391,12 @@ func SetStdHandle(stdHandle uint32, handle syscall.Handle) error {
 }
 
 func TerminateJobObject(job syscall.Handle, exitCode uint32) error {
-	r1, _, e1 := procTerminateJobObject.Call(uintptr(job), uintptr(exitCode))
+	r1, _, e1 := syscall.Syscall(
+		procTerminateJobObject.Addr(),
+		2,
+		uintptr(job),
+		uintptr(exitCode),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -1262,7 +1408,12 @@ func TerminateJobObject(job syscall.Handle, exitCode uint32) error {
 }
 
 func TerminateProcess(process syscall.Handle, exitCode uint32) error {
-	r1, _, e1 := procTerminateProcess.Call(uintptr(process), uintptr(exitCode))
+	r1, _, e1 := syscall.Syscall(
+		procTerminateProcess.Addr(),
+		2,
+		uintptr(process),
+		uintptr(exitCode),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -1274,12 +1425,19 @@ func TerminateProcess(process syscall.Handle, exitCode uint32) error {
 }
 
 func TryEnterCriticalSection(criticalSection *CRITICAL_SECTION) bool {
-	r1, _, _ := procTryEnterCriticalSection.Call(uintptr(unsafe.Pointer(criticalSection)))
+	r1, _, _ := syscall.Syscall(
+		procTryEnterCriticalSection.Addr(),
+		1,
+		uintptr(unsafe.Pointer(criticalSection)),
+		0,
+		0)
 	return r1 != 0
 }
 
 func UpdateResource(update syscall.Handle, resourceType uintptr, name uintptr, language uint16, data *byte, cbData uint32) error {
-	r1, _, e1 := procUpdateResourceW.Call(
+	r1, _, e1 := syscall.Syscall6(
+		procUpdateResourceW.Addr(),
+		6,
 		uintptr(update),
 		resourceType,
 		name,
@@ -1297,7 +1455,9 @@ func UpdateResource(update syscall.Handle, resourceType uintptr, name uintptr, l
 }
 
 func VerifyVersionInfo(versionInfo *OSVERSIONINFOEX, typeMask uint32, conditionMask uint64) error {
-	r1, _, e1 := procVerifyVersionInfoW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procVerifyVersionInfoW.Addr(),
+		3,
 		uintptr(unsafe.Pointer(versionInfo)),
 		uintptr(typeMask),
 		uintptr(conditionMask))
@@ -1312,7 +1472,12 @@ func VerifyVersionInfo(versionInfo *OSVERSIONINFOEX, typeMask uint32, conditionM
 }
 
 func WaitForSingleObject(handle syscall.Handle, milliseconds uint32) (uint32, error) {
-	r1, _, e1 := procWaitForSingleObject.Call(uintptr(handle), uintptr(milliseconds))
+	r1, _, e1 := syscall.Syscall(
+		procWaitForSingleObject.Addr(),
+		2,
+		uintptr(handle),
+		uintptr(milliseconds),
+		0)
 	if r1 == WAIT_FAILED {
 		if e1 != ERROR_SUCCESS {
 			return uint32(r1), e1
@@ -1324,7 +1489,7 @@ func WaitForSingleObject(handle syscall.Handle, milliseconds uint32) (uint32, er
 }
 
 func Lstrlen(string *uint16) int32 {
-	r1, _, _ := proclstrlenW.Call(uintptr(unsafe.Pointer(string)))
+	r1, _, _ := syscall.Syscall(proclstrlenW.Addr(), 1, uintptr(unsafe.Pointer(string)), 0, 0)
 	return int32(r1)
 }
 
@@ -1335,7 +1500,9 @@ func AdjustTokenPrivileges(tokenHandle syscall.Handle, disableAllPrivileges bool
 	} else {
 		disableAllPrivilegesRaw = 0
 	}
-	r1, _, e1 := procAdjustTokenPrivileges.Call(
+	r1, _, e1 := syscall.Syscall6(
+		procAdjustTokenPrivileges.Addr(),
+		6,
 		uintptr(tokenHandle),
 		uintptr(disableAllPrivilegesRaw),
 		uintptr(unsafe.Pointer(newState)),
@@ -1353,7 +1520,9 @@ func AdjustTokenPrivileges(tokenHandle syscall.Handle, disableAllPrivileges bool
 }
 
 func AllocateAndInitializeSid(identifierAuthority *SID_IDENTIFIER_AUTHORITY, subAuthorityCount byte, subAuthority0 uint32, subAuthority1 uint32, subAuthority2 uint32, subAuthority3 uint32, subAuthority4 uint32, subAuthority5 uint32, subAuthority6 uint32, subAuthority7 uint32, sid **SID) error {
-	r1, _, e1 := procAllocateAndInitializeSid.Call(
+	r1, _, e1 := syscall.Syscall12(
+		procAllocateAndInitializeSid.Addr(),
+		11,
 		uintptr(unsafe.Pointer(identifierAuthority)),
 		uintptr(subAuthorityCount),
 		uintptr(subAuthority0),
@@ -1364,7 +1533,8 @@ func AllocateAndInitializeSid(identifierAuthority *SID_IDENTIFIER_AUTHORITY, sub
 		uintptr(subAuthority5),
 		uintptr(subAuthority6),
 		uintptr(subAuthority7),
-		uintptr(unsafe.Pointer(sid)))
+		uintptr(unsafe.Pointer(sid)),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -1377,7 +1547,9 @@ func AllocateAndInitializeSid(identifierAuthority *SID_IDENTIFIER_AUTHORITY, sub
 
 func CheckTokenMembership(tokenHandle syscall.Handle, sidToCheck *SID, isMember *bool) error {
 	var isMemberRaw int32
-	r1, _, e1 := procCheckTokenMembership.Call(
+	r1, _, e1 := syscall.Syscall(
+		procCheckTokenMembership.Addr(),
+		3,
 		uintptr(tokenHandle),
 		uintptr(unsafe.Pointer(sidToCheck)),
 		uintptr(unsafe.Pointer(&isMemberRaw)))
@@ -1395,7 +1567,9 @@ func CheckTokenMembership(tokenHandle syscall.Handle, sidToCheck *SID, isMember 
 }
 
 func CopySid(destinationSidLength uint32, destinationSid *SID, sourceSid *SID) error {
-	r1, _, e1 := procCopySid.Call(
+	r1, _, e1 := syscall.Syscall(
+		procCopySid.Addr(),
+		3,
 		uintptr(destinationSidLength),
 		uintptr(unsafe.Pointer(destinationSid)),
 		uintptr(unsafe.Pointer(sourceSid)))
@@ -1410,7 +1584,7 @@ func CopySid(destinationSidLength uint32, destinationSid *SID, sourceSid *SID) e
 }
 
 func DeregisterEventSource(eventLog syscall.Handle) error {
-	r1, _, e1 := procDeregisterEventSource.Call(uintptr(eventLog))
+	r1, _, e1 := syscall.Syscall(procDeregisterEventSource.Addr(), 1, uintptr(eventLog), 0, 0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -1422,23 +1596,29 @@ func DeregisterEventSource(eventLog syscall.Handle) error {
 }
 
 func EqualSid(sid1 *SID, sid2 *SID) bool {
-	r1, _, _ := procEqualSid.Call(
+	r1, _, _ := syscall.Syscall(
+		procEqualSid.Addr(),
+		2,
 		uintptr(unsafe.Pointer(sid1)),
-		uintptr(unsafe.Pointer(sid2)))
+		uintptr(unsafe.Pointer(sid2)),
+		0)
 	return r1 != 0
 }
 
 func FreeSid(sid *SID) {
-	procFreeSid.Call(uintptr(unsafe.Pointer(sid)))
+	syscall.Syscall(procFreeSid.Addr(), 1, uintptr(unsafe.Pointer(sid)), 0, 0)
 }
 
 func GetFileSecurity(fileName *uint16, requestedInformation uint32, securityDescriptor *byte, length uint32, lengthNeeded *uint32) error {
-	r1, _, e1 := procGetFileSecurityW.Call(
+	r1, _, e1 := syscall.Syscall6(
+		procGetFileSecurityW.Addr(),
+		5,
 		uintptr(unsafe.Pointer(fileName)),
 		uintptr(requestedInformation),
 		uintptr(unsafe.Pointer(securityDescriptor)),
 		uintptr(length),
-		uintptr(unsafe.Pointer(lengthNeeded)))
+		uintptr(unsafe.Pointer(lengthNeeded)),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -1450,13 +1630,15 @@ func GetFileSecurity(fileName *uint16, requestedInformation uint32, securityDesc
 }
 
 func GetLengthSid(sid *SID) uint32 {
-	r1, _, _ := procGetLengthSid.Call(uintptr(unsafe.Pointer(sid)))
+	r1, _, _ := syscall.Syscall(procGetLengthSid.Addr(), 1, uintptr(unsafe.Pointer(sid)), 0, 0)
 	return uint32(r1)
 }
 
 func GetSecurityDescriptorOwner(securityDescriptor *byte, owner **SID, ownerDefaulted *bool) error {
 	var ownerDefaultedRaw int32
-	r1, _, e1 := procGetSecurityDescriptorOwner.Call(
+	r1, _, e1 := syscall.Syscall(
+		procGetSecurityDescriptorOwner.Addr(),
+		3,
 		uintptr(unsafe.Pointer(securityDescriptor)),
 		uintptr(unsafe.Pointer(owner)),
 		uintptr(unsafe.Pointer(&ownerDefaultedRaw)))
@@ -1474,12 +1656,15 @@ func GetSecurityDescriptorOwner(securityDescriptor *byte, owner **SID, ownerDefa
 }
 
 func GetTokenInformation(tokenHandle syscall.Handle, tokenInformationClass int32, tokenInformation *byte, tokenInformationLength uint32, returnLength *uint32) error {
-	r1, _, e1 := procGetTokenInformation.Call(
+	r1, _, e1 := syscall.Syscall6(
+		procGetTokenInformation.Addr(),
+		5,
 		uintptr(tokenHandle),
 		uintptr(tokenInformationClass),
 		uintptr(unsafe.Pointer(tokenInformation)),
 		uintptr(tokenInformationLength),
-		uintptr(unsafe.Pointer(returnLength)))
+		uintptr(unsafe.Pointer(returnLength)),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -1491,7 +1676,7 @@ func GetTokenInformation(tokenHandle syscall.Handle, tokenInformationClass int32
 }
 
 func ImpersonateSelf(impersonationLevel int32) error {
-	r1, _, e1 := procImpersonateSelf.Call(uintptr(impersonationLevel))
+	r1, _, e1 := syscall.Syscall(procImpersonateSelf.Addr(), 1, uintptr(impersonationLevel), 0, 0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -1503,7 +1688,9 @@ func ImpersonateSelf(impersonationLevel int32) error {
 }
 
 func LookupPrivilegeValue(systemName *uint16, name *uint16, luid *LUID) error {
-	r1, _, e1 := procLookupPrivilegeValueW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procLookupPrivilegeValueW.Addr(),
+		3,
 		uintptr(unsafe.Pointer(systemName)),
 		uintptr(unsafe.Pointer(name)),
 		uintptr(unsafe.Pointer(luid)))
@@ -1518,7 +1705,9 @@ func LookupPrivilegeValue(systemName *uint16, name *uint16, luid *LUID) error {
 }
 
 func OpenProcessToken(processHandle syscall.Handle, desiredAccess uint32, tokenHandle *syscall.Handle) error {
-	r1, _, e1 := procOpenProcessToken.Call(
+	r1, _, e1 := syscall.Syscall(
+		procOpenProcessToken.Addr(),
+		3,
 		uintptr(processHandle),
 		uintptr(desiredAccess),
 		uintptr(unsafe.Pointer(tokenHandle)))
@@ -1539,11 +1728,15 @@ func OpenThreadToken(threadHandle syscall.Handle, desiredAccess uint32, openAsSe
 	} else {
 		openAsSelfRaw = 0
 	}
-	r1, _, e1 := procOpenThreadToken.Call(
+	r1, _, e1 := syscall.Syscall6(
+		procOpenThreadToken.Addr(),
+		4,
 		uintptr(threadHandle),
 		uintptr(desiredAccess),
 		uintptr(openAsSelfRaw),
-		uintptr(unsafe.Pointer(tokenHandle)))
+		uintptr(unsafe.Pointer(tokenHandle)),
+		0,
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -1555,9 +1748,12 @@ func OpenThreadToken(threadHandle syscall.Handle, desiredAccess uint32, openAsSe
 }
 
 func RegisterEventSource(uncServerName *uint16, sourceName *uint16) (syscall.Handle, error) {
-	r1, _, e1 := procRegisterEventSourceW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procRegisterEventSourceW.Addr(),
+		2,
 		uintptr(unsafe.Pointer(uncServerName)),
-		uintptr(unsafe.Pointer(sourceName)))
+		uintptr(unsafe.Pointer(sourceName)),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return 0, e1
@@ -1569,7 +1765,9 @@ func RegisterEventSource(uncServerName *uint16, sourceName *uint16) (syscall.Han
 }
 
 func ReportEvent(eventLog syscall.Handle, eventType uint16, category uint16, eventID uint32, userSid *SID, numStrings uint16, dataSize uint32, strings **uint16, rawData *byte) error {
-	r1, _, e1 := procReportEventW.Call(
+	r1, _, e1 := syscall.Syscall9(
+		procReportEventW.Addr(),
+		9,
 		uintptr(eventLog),
 		uintptr(eventType),
 		uintptr(category),
@@ -1590,7 +1788,7 @@ func ReportEvent(eventLog syscall.Handle, eventType uint16, category uint16, eve
 }
 
 func RevertToSelf() error {
-	r1, _, e1 := procRevertToSelf.Call()
+	r1, _, e1 := syscall.Syscall(procRevertToSelf.Addr(), 0, 0, 0, 0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1

--- a/wrappers/wincon.go
+++ b/wrappers/wincon.go
@@ -44,7 +44,12 @@ var (
 )
 
 func GenerateConsoleCtrlEvent(ctrlEvent uint32, processGroupId uint32) error {
-	r1, _, e1 := procGenerateConsoleCtrlEvent.Call(uintptr(ctrlEvent), uintptr(processGroupId))
+	r1, _, e1 := syscall.Syscall(
+		procGenerateConsoleCtrlEvent.Addr(),
+		2,
+		uintptr(ctrlEvent),
+		uintptr(processGroupId),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1

--- a/wrappers/wininet.go
+++ b/wrappers/wininet.go
@@ -220,7 +220,9 @@ var (
 )
 
 func HttpOpenRequest(connect syscall.Handle, verb *uint16, objectName *uint16, version *uint16, referer *uint16, acceptTypes **uint16, flags uint32, context uintptr) (syscall.Handle, error) {
-	r1, _, e1 := procHttpOpenRequestW.Call(
+	r1, _, e1 := syscall.Syscall9(
+		procHttpOpenRequestW.Addr(),
+		8,
 		uintptr(connect),
 		uintptr(unsafe.Pointer(verb)),
 		uintptr(unsafe.Pointer(objectName)),
@@ -228,7 +230,8 @@ func HttpOpenRequest(connect syscall.Handle, verb *uint16, objectName *uint16, v
 		uintptr(unsafe.Pointer(referer)),
 		uintptr(unsafe.Pointer(acceptTypes)),
 		uintptr(flags),
-		uintptr(context))
+		uintptr(context),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return 0, e1
@@ -240,12 +243,15 @@ func HttpOpenRequest(connect syscall.Handle, verb *uint16, objectName *uint16, v
 }
 
 func HttpQueryInfo(request syscall.Handle, infoLevel uint32, buffer *byte, bufferLength *uint32, index *uint32) error {
-	r1, _, e1 := procHttpQueryInfoW.Call(
+	r1, _, e1 := syscall.Syscall6(
+		procHttpQueryInfoW.Addr(),
+		5,
 		uintptr(request),
 		uintptr(infoLevel),
 		uintptr(unsafe.Pointer(buffer)),
 		uintptr(unsafe.Pointer(bufferLength)),
-		uintptr(unsafe.Pointer(index)))
+		uintptr(unsafe.Pointer(index)),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -257,12 +263,15 @@ func HttpQueryInfo(request syscall.Handle, infoLevel uint32, buffer *byte, buffe
 }
 
 func HttpSendRequest(request syscall.Handle, headers *uint16, headersLength uint32, optional *byte, optionalLength uint32) error {
-	r1, _, e1 := procHttpSendRequestW.Call(
+	r1, _, e1 := syscall.Syscall6(
+		procHttpSendRequestW.Addr(),
+		5,
 		uintptr(request),
 		uintptr(unsafe.Pointer(headers)),
 		uintptr(headersLength),
 		uintptr(unsafe.Pointer(optional)),
-		uintptr(optionalLength))
+		uintptr(optionalLength),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -274,7 +283,7 @@ func HttpSendRequest(request syscall.Handle, headers *uint16, headersLength uint
 }
 
 func InternetCloseHandle(internet syscall.Handle) error {
-	r1, _, e1 := procInternetCloseHandle.Call(uintptr(internet))
+	r1, _, e1 := syscall.Syscall(procInternetCloseHandle.Addr(), 1, uintptr(internet), 0, 0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -286,7 +295,9 @@ func InternetCloseHandle(internet syscall.Handle) error {
 }
 
 func InternetConnect(internet syscall.Handle, serverName *uint16, serverPort uint16, username *uint16, password *uint16, service uint32, flags uint32, context uintptr) (syscall.Handle, error) {
-	r1, _, e1 := procInternetConnectW.Call(
+	r1, _, e1 := syscall.Syscall9(
+		procInternetConnectW.Addr(),
+		8,
 		uintptr(internet),
 		uintptr(unsafe.Pointer(serverName)),
 		uintptr(serverPort),
@@ -294,7 +305,8 @@ func InternetConnect(internet syscall.Handle, serverName *uint16, serverPort uin
 		uintptr(unsafe.Pointer(password)),
 		uintptr(service),
 		uintptr(flags),
-		context)
+		context,
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return 0, e1
@@ -306,12 +318,15 @@ func InternetConnect(internet syscall.Handle, serverName *uint16, serverPort uin
 }
 
 func InternetOpen(agent *uint16, accessType uint32, proxyName *uint16, proxyBypass *uint16, flags uint32) (syscall.Handle, error) {
-	r1, _, e1 := procInternetOpenW.Call(
+	r1, _, e1 := syscall.Syscall6(
+		procInternetOpenW.Addr(),
+		5,
 		uintptr(unsafe.Pointer(agent)),
 		uintptr(accessType),
 		uintptr(unsafe.Pointer(proxyName)),
 		uintptr(unsafe.Pointer(proxyBypass)),
-		uintptr(flags))
+		uintptr(flags),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return 0, e1
@@ -323,7 +338,9 @@ func InternetOpen(agent *uint16, accessType uint32, proxyName *uint16, proxyBypa
 }
 
 func InternetOpenUrl(internet syscall.Handle, url *uint16, headers *uint16, headersLength uint32, flags uint32, context uintptr) (syscall.Handle, error) {
-	r1, _, e1 := procInternetOpenUrlW.Call(
+	r1, _, e1 := syscall.Syscall6(
+		procInternetOpenUrlW.Addr(),
+		6,
 		uintptr(internet),
 		uintptr(unsafe.Pointer(url)),
 		uintptr(unsafe.Pointer(headers)),
@@ -341,11 +358,15 @@ func InternetOpenUrl(internet syscall.Handle, url *uint16, headers *uint16, head
 }
 
 func InternetReadFile(file syscall.Handle, buffer *byte, numberOfBytesToRead uint32, numberOfBytesRead *uint32) error {
-	r1, _, e1 := procInternetReadFile.Call(
+	r1, _, e1 := syscall.Syscall6(
+		procInternetReadFile.Addr(),
+		4,
 		uintptr(file),
 		uintptr(unsafe.Pointer(buffer)),
 		uintptr(numberOfBytesToRead),
-		uintptr(unsafe.Pointer(numberOfBytesRead)))
+		uintptr(unsafe.Pointer(numberOfBytesRead)),
+		0,
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -357,11 +378,15 @@ func InternetReadFile(file syscall.Handle, buffer *byte, numberOfBytesToRead uin
 }
 
 func InternetQueryDataAvailable(file syscall.Handle, numberOfBytesAvailable *uint32, flags uint32, context uintptr) error {
-	r1, _, e1 := procInternetQueryDataAvailable.Call(
+	r1, _, e1 := syscall.Syscall6(
+		procInternetQueryDataAvailable.Addr(),
+		4,
 		uintptr(file),
 		uintptr(unsafe.Pointer(numberOfBytesAvailable)),
 		uintptr(flags),
-		context)
+		context,
+		0,
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1

--- a/wrappers/winnls.go
+++ b/wrappers/winnls.go
@@ -34,9 +34,12 @@ var (
 )
 
 func LocaleNameToLCID(name *uint16, flags uint32) (uint32, error) {
-	r1, _, e1 := procLocaleNameToLCID.Call(
+	r1, _, e1 := syscall.Syscall(
+		procLocaleNameToLCID.Addr(),
+		2,
 		uintptr(unsafe.Pointer(name)),
-		uintptr(flags))
+		uintptr(flags),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return 0, e1

--- a/wrappers/winnt.go
+++ b/wrappers/winnt.go
@@ -1357,18 +1357,27 @@ var (
 )
 
 func RtlMoveMemory(destination *byte, source *byte, length uintptr) {
-	procRtlMoveMemory.Call(
+	syscall.Syscall(
+		procRtlMoveMemory.Addr(),
+		3,
 		uintptr(unsafe.Pointer(destination)),
 		uintptr(unsafe.Pointer(source)),
 		length)
 }
 
 func RtlZeroMemory(destination *byte, length uintptr) {
-	procRtlZeroMemory.Call(uintptr(unsafe.Pointer(destination)), length)
+	syscall.Syscall(
+		procRtlZeroMemory.Addr(),
+		2,
+		uintptr(unsafe.Pointer(destination)),
+		length,
+		0)
 }
 
 func VerSetConditionMask(conditionMask uint64, typeBitMask uint32, condition uint8) uint64 {
-	r1, _, _ := procVerSetConditionMask.Call(
+	r1, _, _ := syscall.Syscall(
+		procVerSetConditionMask.Addr(),
+		3,
 		uintptr(conditionMask),
 		uintptr(typeBitMask),
 		uintptr(condition))

--- a/wrappers/winreg.go
+++ b/wrappers/winreg.go
@@ -48,7 +48,7 @@ var (
 )
 
 func RegCloseKey(key syscall.Handle) error {
-	r1, _, _ := procRegCloseKey.Call(uintptr(key))
+	r1, _, _ := syscall.Syscall(procRegCloseKey.Addr(), 1, uintptr(key), 0, 0)
 	if err := syscall.Errno(r1); err != ERROR_SUCCESS {
 		return err
 	}
@@ -56,7 +56,9 @@ func RegCloseKey(key syscall.Handle) error {
 }
 
 func RegCreateKeyEx(key syscall.Handle, subKey *uint16, reserved uint32, class *uint16, options uint32, samDesired uint32, securityAttributes *syscall.SecurityAttributes, result *syscall.Handle, disposition *uint32) error {
-	r1, _, _ := procRegCreateKeyExW.Call(
+	r1, _, _ := syscall.Syscall9(
+		procRegCreateKeyExW.Addr(),
+		9,
 		uintptr(key),
 		uintptr(unsafe.Pointer(subKey)),
 		uintptr(reserved),
@@ -73,9 +75,12 @@ func RegCreateKeyEx(key syscall.Handle, subKey *uint16, reserved uint32, class *
 }
 
 func RegDeleteKey(key syscall.Handle, subKey *uint16) error {
-	r1, _, _ := procRegDeleteKeyW.Call(
+	r1, _, _ := syscall.Syscall(
+		procRegDeleteKeyW.Addr(),
+		2,
 		uintptr(key),
-		uintptr(unsafe.Pointer(subKey)))
+		uintptr(unsafe.Pointer(subKey)),
+		0)
 	if err := syscall.Errno(r1); err != ERROR_SUCCESS {
 		return err
 	}
@@ -83,9 +88,12 @@ func RegDeleteKey(key syscall.Handle, subKey *uint16) error {
 }
 
 func RegDeleteValue(key syscall.Handle, valueName *uint16) error {
-	r1, _, _ := procRegDeleteValueW.Call(
+	r1, _, _ := syscall.Syscall(
+		procRegDeleteValueW.Addr(),
+		2,
 		uintptr(key),
-		uintptr(unsafe.Pointer(valueName)))
+		uintptr(unsafe.Pointer(valueName)),
+		0)
 	if err := syscall.Errno(r1); err != ERROR_SUCCESS {
 		return err
 	}
@@ -93,7 +101,9 @@ func RegDeleteValue(key syscall.Handle, valueName *uint16) error {
 }
 
 func RegEnumKeyEx(key syscall.Handle, index uint32, name *uint16, cName *uint32, reserved *uint32, class *uint16, cClass *uint32, lastWriteTime *FILETIME) error {
-	r1, _,_ := procRegEnumKeyExW.Call(
+	r1, _,_ := syscall.Syscall9(
+		procRegEnumKeyExW.Addr(),
+		8,
 		uintptr(key),
 		uintptr(index),
 		uintptr(unsafe.Pointer(name)),
@@ -101,7 +111,8 @@ func RegEnumKeyEx(key syscall.Handle, index uint32, name *uint16, cName *uint32,
 		uintptr(unsafe.Pointer(reserved)),
 		uintptr(unsafe.Pointer(class)),
 		uintptr(unsafe.Pointer(cClass)),
-		uintptr(unsafe.Pointer(lastWriteTime)))
+		uintptr(unsafe.Pointer(lastWriteTime)),
+		0)
 	if err := syscall.Errno(r1); err != ERROR_SUCCESS {
 		return err
 	}
@@ -109,7 +120,9 @@ func RegEnumKeyEx(key syscall.Handle, index uint32, name *uint16, cName *uint32,
 }
 
 func RegEnumValue(key syscall.Handle, index uint32, valueName *uint16, cchValueName *uint32, reserved *uint32, valueType *uint32, data *byte, cbData *uint32) error {
-	r1, _, _ := procRegEnumValueW.Call(
+	r1, _, _ := syscall.Syscall9(
+		procRegEnumValueW.Addr(),
+		8,
 		uintptr(key),
 		uintptr(index),
 		uintptr(unsafe.Pointer(valueName)),
@@ -117,7 +130,8 @@ func RegEnumValue(key syscall.Handle, index uint32, valueName *uint16, cchValueN
 		uintptr(unsafe.Pointer(reserved)),
 		uintptr(unsafe.Pointer(valueType)),
 		uintptr(unsafe.Pointer(data)),
-		uintptr(unsafe.Pointer(cbData)))
+		uintptr(unsafe.Pointer(cbData)),
+		0)
 	if err := syscall.Errno(r1); err != ERROR_SUCCESS {
 		return err
 	}
@@ -125,12 +139,15 @@ func RegEnumValue(key syscall.Handle, index uint32, valueName *uint16, cchValueN
 }
 
 func RegOpenKeyEx(key syscall.Handle, subKey *uint16, options uint32, samDesired uint32, result *syscall.Handle) error {
-	r1, _, _ := procRegOpenKeyExW.Call(
+	r1, _, _ := syscall.Syscall6(
+		procRegOpenKeyExW.Addr(),
+		5,
 		uintptr(key),
 		uintptr(unsafe.Pointer(subKey)),
 		uintptr(options),
 		uintptr(samDesired),
-		uintptr(unsafe.Pointer(result)))
+		uintptr(unsafe.Pointer(result)),
+		0)
 	if err := syscall.Errno(r1); err != ERROR_SUCCESS {
 		return err
 	}
@@ -138,7 +155,9 @@ func RegOpenKeyEx(key syscall.Handle, subKey *uint16, options uint32, samDesired
 }
 
 func RegQueryInfoKey(key syscall.Handle, class *uint16, cClass *uint32, reserved *uint32, subKeys *uint32, maxSubKeyLen *uint32, maxClassLen *uint32, values *uint32, maxValueNameLen *uint32, maxValueLen *uint32, cbSecurityDescriptor *uint32, lastWriteTime *FILETIME) error {
-	r1, _, _ := procRegQueryInfoKeyW.Call(
+	r1, _, _ := syscall.Syscall12(
+		procRegQueryInfoKeyW.Addr(),
+		12,
 		uintptr(key),
 		uintptr(unsafe.Pointer(class)),
 		uintptr(unsafe.Pointer(cClass)),
@@ -158,7 +177,9 @@ func RegQueryInfoKey(key syscall.Handle, class *uint16, cClass *uint32, reserved
 }
 
 func RegQueryValueEx(key syscall.Handle, valueName *uint16, reserved *uint32, valueType *uint32, data *byte, cbData *uint32) error {
-	r1, _, _ := procRegQueryValueExW.Call(
+	r1, _, _ := syscall.Syscall6(
+		procRegQueryValueExW.Addr(),
+		6,
 		uintptr(key),
 		uintptr(unsafe.Pointer(valueName)),
 		uintptr(unsafe.Pointer(reserved)),
@@ -172,7 +193,9 @@ func RegQueryValueEx(key syscall.Handle, valueName *uint16, reserved *uint32, va
 }
 
 func RegSetValueEx(key syscall.Handle, valueName *uint16, reserved uint32, valueType uint32, data *byte, cbData uint32) error {
-	r1, _, _ := procRegSetValueExW.Call(
+	r1, _, _ := syscall.Syscall6(
+		procRegSetValueExW.Addr(),
+		6,
 		uintptr(key),
 		uintptr(unsafe.Pointer(valueName)),
 		uintptr(reserved),

--- a/wrappers/winsvc.go
+++ b/wrappers/winsvc.go
@@ -255,7 +255,9 @@ var (
 )
 
 func ChangeServiceConfig(service syscall.Handle, serviceType uint32, startType uint32, errorControl uint32, binaryPathName *uint16, loadOrderGroup *uint16, tagId *uint32, dependencies *uint16, serviceStartName *uint16, password *uint16, displayName *uint16) error {
-	r1, _, e1 := procChangeServiceConfigW.Call(
+	r1, _, e1 := syscall.Syscall12(
+		procChangeServiceConfigW.Addr(),
+		11,
 		uintptr(service),
 		uintptr(serviceType),
 		uintptr(startType),
@@ -266,7 +268,8 @@ func ChangeServiceConfig(service syscall.Handle, serviceType uint32, startType u
 		uintptr(unsafe.Pointer(dependencies)),
 		uintptr(unsafe.Pointer(serviceStartName)),
 		uintptr(unsafe.Pointer(password)),
-		uintptr(unsafe.Pointer(displayName)))
+		uintptr(unsafe.Pointer(displayName)),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -278,7 +281,9 @@ func ChangeServiceConfig(service syscall.Handle, serviceType uint32, startType u
 }
 
 func ChangeServiceConfig2(service syscall.Handle, infoLevel uint32, info *byte) error {
-	r1, _, e1 := procChangeServiceConfig2W.Call(
+	r1, _, e1 := syscall.Syscall(
+		procChangeServiceConfig2W.Addr(),
+		3,
 		uintptr(service),
 		uintptr(infoLevel),
 		uintptr(unsafe.Pointer(info)))
@@ -293,7 +298,7 @@ func ChangeServiceConfig2(service syscall.Handle, infoLevel uint32, info *byte) 
 }
 
 func CloseServiceHandle(scObject syscall.Handle) error {
-	r1, _, e1 := procCloseServiceHandle.Call(uintptr(scObject))
+	r1, _, e1 := syscall.Syscall(procCloseServiceHandle.Addr(), 1, uintptr(scObject), 0, 0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -305,7 +310,9 @@ func CloseServiceHandle(scObject syscall.Handle) error {
 }
 
 func ControlService(service syscall.Handle, control uint32, serviceStatus *SERVICE_STATUS) error {
-	r1, _, e1 := procControlService.Call(
+	r1, _, e1 := syscall.Syscall(
+		procControlService.Addr(),
+		3,
 		uintptr(service),
 		uintptr(control),
 		uintptr(unsafe.Pointer(serviceStatus)))
@@ -320,7 +327,9 @@ func ControlService(service syscall.Handle, control uint32, serviceStatus *SERVI
 }
 
 func CreateService(scManager syscall.Handle, serviceName *uint16, databaseName *uint16, desiredAccess uint32, serviceType uint32, startType uint32, errorControl uint32, binaryPathName *uint16, loadOrderGroup *uint16, tagId *uint32, dependencies *uint16, serviceStartName *uint16, password *uint16) (syscall.Handle, error) {
-	r1, _, e1 := procCreateServiceW.Call(
+	r1, _, e1 := syscall.Syscall15(
+		procCreateServiceW.Addr(),
+		13,
 		uintptr(scManager),
 		uintptr(unsafe.Pointer(serviceName)),
 		uintptr(unsafe.Pointer(databaseName)),
@@ -333,7 +342,9 @@ func CreateService(scManager syscall.Handle, serviceName *uint16, databaseName *
 		uintptr(unsafe.Pointer(tagId)),
 		uintptr(unsafe.Pointer(dependencies)),
 		uintptr(unsafe.Pointer(serviceStartName)),
-		uintptr(unsafe.Pointer(password)))
+		uintptr(unsafe.Pointer(password)),
+		0,
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return 0, e1
@@ -345,7 +356,7 @@ func CreateService(scManager syscall.Handle, serviceName *uint16, databaseName *
 }
 
 func DeleteService(service syscall.Handle) error {
-	r1, _, e1 := procDeleteService.Call(uintptr(service))
+	r1, _, e1 := syscall.Syscall(procDeleteService.Addr(), 1, uintptr(service), 0, 0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -357,7 +368,9 @@ func DeleteService(service syscall.Handle) error {
 }
 
 func EnumServicesStatus(scManager syscall.Handle, serviceType uint32, serviceState uint32, services *byte, bufSize uint32, bytesNeeded *uint32, servicesReturned *uint32, resumeHandle *uint32) error {
-	r1, _, e1 := procEnumServicesStatusW.Call(
+	r1, _, e1 := syscall.Syscall9(
+		procEnumServicesStatusW.Addr(),
+		8,
 		uintptr(scManager),
 		uintptr(serviceType),
 		uintptr(serviceState),
@@ -365,7 +378,8 @@ func EnumServicesStatus(scManager syscall.Handle, serviceType uint32, serviceSta
 		uintptr(bufSize),
 		uintptr(unsafe.Pointer(bytesNeeded)),
 		uintptr(unsafe.Pointer(servicesReturned)),
-		uintptr(unsafe.Pointer(resumeHandle)))
+		uintptr(unsafe.Pointer(resumeHandle)),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -377,7 +391,9 @@ func EnumServicesStatus(scManager syscall.Handle, serviceType uint32, serviceSta
 }
 
 func OpenSCManager(machineName *uint16, databaseName *uint16, desiredAccess uint32) (syscall.Handle, error) {
-	r1, _, e1 := procOpenSCManagerW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procOpenSCManagerW.Addr(),
+		3,
 		uintptr(unsafe.Pointer(machineName)),
 		uintptr(unsafe.Pointer(databaseName)),
 		uintptr(desiredAccess))
@@ -392,7 +408,9 @@ func OpenSCManager(machineName *uint16, databaseName *uint16, desiredAccess uint
 }
 
 func OpenService(scManager syscall.Handle, serviceName *uint16, desiredAccess uint32) (syscall.Handle, error) {
-	r1, _, e1 := procOpenServiceW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procOpenServiceW.Addr(),
+		3,
 		uintptr(scManager),
 		uintptr(unsafe.Pointer(serviceName)),
 		uintptr(desiredAccess))
@@ -407,11 +425,15 @@ func OpenService(scManager syscall.Handle, serviceName *uint16, desiredAccess ui
 }
 
 func QueryServiceConfig(service syscall.Handle, serviceConfig *QUERY_SERVICE_CONFIG, bufSize uint32, bytesNeeded *uint32) error {
-	r1, _, e1 := procQueryServiceConfigW.Call(
+	r1, _, e1 := syscall.Syscall6(
+		procQueryServiceConfigW.Addr(),
+		4,
 		uintptr(service),
 		uintptr(unsafe.Pointer(serviceConfig)),
 		uintptr(bufSize),
-		uintptr(unsafe.Pointer(bytesNeeded)))
+		uintptr(unsafe.Pointer(bytesNeeded)),
+		0,
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -423,12 +445,15 @@ func QueryServiceConfig(service syscall.Handle, serviceConfig *QUERY_SERVICE_CON
 }
 
 func QueryServiceConfig2(service syscall.Handle, infoLevel uint32, buffer *byte, bufSize uint32, bytesNeeded *uint32) error {
-	r1, _, e1 := procQueryServiceConfig2W.Call(
+	r1, _, e1 := syscall.Syscall6(
+		procQueryServiceConfig2W.Addr(),
+		5,
 		uintptr(service),
 		uintptr(infoLevel),
 		uintptr(unsafe.Pointer(buffer)),
 		uintptr(bufSize),
-		uintptr(unsafe.Pointer(bytesNeeded)))
+		uintptr(unsafe.Pointer(bytesNeeded)),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -440,9 +465,12 @@ func QueryServiceConfig2(service syscall.Handle, infoLevel uint32, buffer *byte,
 }
 
 func QueryServiceStatus(service syscall.Handle, serviceStatus *SERVICE_STATUS) error {
-	r1, _, e1 := procQueryServiceStatus.Call(
+	r1, _, e1 := syscall.Syscall(
+		procQueryServiceStatus.Addr(),
+		2,
 		uintptr(service),
-		uintptr(unsafe.Pointer(serviceStatus)))
+		uintptr(unsafe.Pointer(serviceStatus)),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -454,12 +482,15 @@ func QueryServiceStatus(service syscall.Handle, serviceStatus *SERVICE_STATUS) e
 }
 
 func QueryServiceStatusEx(service syscall.Handle, infoLevel int32, buffer *byte, bufSize uint32, bytesNeeded *uint32) error {
-	r1, _, e1 := procQueryServiceStatusEx.Call(
+	r1, _, e1 := syscall.Syscall6(
+		procQueryServiceStatusEx.Addr(),
+		5,
 		uintptr(service),
 		uintptr(infoLevel),
 		uintptr(unsafe.Pointer(buffer)),
 		uintptr(bufSize),
-		uintptr(unsafe.Pointer(bytesNeeded)))
+		uintptr(unsafe.Pointer(bytesNeeded)),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -471,7 +502,9 @@ func QueryServiceStatusEx(service syscall.Handle, infoLevel int32, buffer *byte,
 }
 
 func StartService(service syscall.Handle, numServiceArgs uint32, serviceArgVectors **uint16) error {
-	r1, _, e1 := procStartServiceW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procStartServiceW.Addr(),
+		3,
 		uintptr(service),
 		uintptr(numServiceArgs),
 		uintptr(unsafe.Pointer(serviceArgVectors)))

--- a/wrappers/winternl.go
+++ b/wrappers/winternl.go
@@ -85,11 +85,14 @@ var (
 )
 
 func NtQueryInformationProcess(processHandle syscall.Handle, processInformationClass int32, processInformation *byte, processInformationLength uint32, returnLength *uint32) uint32 {
-	r1, _, _ := procNtQueryInformationProcess.Call(
+	r1, _, _ := syscall.Syscall6(
+		procNtQueryInformationProcess.Addr(),
+		5,
 		uintptr(processHandle),
 		uintptr(processInformationClass),
 		uintptr(unsafe.Pointer(processInformation)),
 		uintptr(processInformationLength),
-		uintptr(unsafe.Pointer(returnLength)))
+		uintptr(unsafe.Pointer(returnLength)),
+		0)
 	return uint32(r1)
 }

--- a/wrappers/winver.go
+++ b/wrappers/winver.go
@@ -30,11 +30,15 @@ var (
 )
 
 func GetFileVersionInfo(filename *uint16, handle uint32, len uint32, data *byte) error {
-	r1, _, e1 := procGetFileVersionInfoW.Call(
+	r1, _, e1 := syscall.Syscall6(
+		procGetFileVersionInfoW.Addr(),
+		4,
 		uintptr(unsafe.Pointer(filename)),
 		uintptr(handle),
 		uintptr(len),
-		uintptr(unsafe.Pointer(data)))
+		uintptr(unsafe.Pointer(data)),
+		0,
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1
@@ -46,9 +50,12 @@ func GetFileVersionInfo(filename *uint16, handle uint32, len uint32, data *byte)
 }
 
 func GetFileVersionInfoSize(filename *uint16, handle *uint32) (uint32, error) {
-	r1, _, e1 := procGetFileVersionInfoSizeW.Call(
+	r1, _, e1 := syscall.Syscall(
+		procGetFileVersionInfoSizeW.Addr(),
+		2,
 		uintptr(unsafe.Pointer(filename)),
-		uintptr(unsafe.Pointer(handle)))
+		uintptr(unsafe.Pointer(handle)),
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return 0, e1
@@ -60,11 +67,15 @@ func GetFileVersionInfoSize(filename *uint16, handle *uint32) (uint32, error) {
 }
 
 func VerQueryValue(block *byte, subBlock *uint16, buffer **byte, len *uint32) error {
-	r1, _, e1 := procVerQueryValueW.Call(
+	r1, _, e1 := syscall.Syscall6(
+		procVerQueryValueW.Addr(),
+		4,
 		uintptr(unsafe.Pointer(block)),
 		uintptr(unsafe.Pointer(subBlock)),
 		uintptr(unsafe.Pointer(buffer)),
-		uintptr(unsafe.Pointer(len)))
+		uintptr(unsafe.Pointer(len)),
+		0,
+		0)
 	if r1 == 0 {
 		if e1 != ERROR_SUCCESS {
 			return e1


### PR DESCRIPTION
@markbenvenuto The `Call` function that we were using to make Win32 API calls seems to no longer work properly with Go 1.6, at least with certain functions.  There was an issue where `RegCreateKeyEx` didn't work right because the handle being passed back through a pointer was coming back as invalid.  The Go runtime used `syscall.Syscall` directly instead for its internal wrappers, and changing our wrappers to use that as well fixes the bug.  It's probably better to go this route anyway from the perspective of long-term stability, since if the Go runtime uses it internally it means that it's getting regularly tested by the Go team.